### PR TITLE
[Enhancement]番組名や概要の全角英数字記号を半角にする/しないを選択するオプションの追加

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -6,6 +6,7 @@
     "ffmpeg": "/usr/local/bin/ffmpeg",
     "ffprobe": "/usr/local/bin/ffprobe",
     "maxEncode": 2,
+    "convertTwoByteToOneByte": true,
     "encode": [
         {
             "name": "H264",

--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -11,6 +11,7 @@
     - [PostgreSQL の設定を変更したい](#postgresql)
     - [SQLite3 の設定を変更したい](#sqlite3)
     - [SQLite3 のデータベース保存先を変更したい](#dbpath)
+    - [番組名や概要に含まれる半角英数字記号を全角にしたい](#converttwobytetoonebyte)
     - [利用する FFmpeg を明示的に指定したい](#ffmpeg)
     - [利用する FFprobe を明示的に指定したい](#ffprobe)
 - [詳細設定](#詳細設定)
@@ -232,6 +233,18 @@
 ```json
 "dbPath": "/hoge/database.db"
 ```
+
+### convertTwoByteToOneByte
+#### 番組名や概要などに含まれる全角英数字記号を半角に変換する
+
+| 種類 | デフォルト値 | 必須 |
+| --- | ---------- | --- |
+| boolean | true | no |
+
+```json
+"convertTwoByteToOneByte": true
+```
+
 
 ### ffmpeg
 #### EPGStation が利用する FFmpeg のパス

--- a/src/server/ConfigInterface.ts
+++ b/src/server/ConfigInterface.ts
@@ -72,6 +72,7 @@ interface ConfigInterface {
     ffmpeg: string;
     ffprobe: string;
     maxEncode: number;
+    convertTwoByteToOneByte: boolean;
     encode: {
         name: string;
         cmd: string;

--- a/src/server/Model/DB/ProgramsDB.ts
+++ b/src/server/Model/DB/ProgramsDB.ts
@@ -175,7 +175,7 @@ abstract class ProgramsDB extends DBTableBase implements ProgramsDBInterface {
             const channelType = channelTypes[program.networkId][program.serviceId].type;
             const channel = channelTypes[program.networkId][program.serviceId].channel;
 
-            const name = config.convertTwoByteToOneByte ? StrUtil.toHalf(program.name) : program.name;
+            const name = StrUtil.toDBStr(program.name, config.convertTwoByteToOneByte);
             const tmp = [
                 program.id,
                 parseInt(program.networkId + (program.serviceId / 100000).toFixed(5).slice(2), 10),
@@ -190,7 +190,7 @@ abstract class ProgramsDB extends DBTableBase implements ProgramsDBInterface {
                 program.isFree,
                 name,
                 StrUtil.deleteBrackets(name),
-                typeof program.description === 'undefined' || program.description === '' ? null : config.convertTwoByteToOneByte ? StrUtil.toHalf(program.description) : program.description,
+                typeof program.description === 'undefined' || program.description === '' ? null : StrUtil.toDBStr(program.description, config.convertTwoByteToOneByte),
                 this.createExtendedStr(program.extended, config.convertTwoByteToOneByte),
                 genre1,
                 genre2,
@@ -292,7 +292,7 @@ abstract class ProgramsDB extends DBTableBase implements ProgramsDBInterface {
             }
         }
 
-        const ret = convertTwoByteToOneByte ? StrUtil.toHalf(str).trim() : str.trim();
+        const ret = StrUtil.toDBStr(str, convertTwoByteToOneByte).trim();
 
         return ret;
     }
@@ -754,7 +754,7 @@ abstract class ProgramsDB extends DBTableBase implements ProgramsDBInterface {
 
             // あいまい検索
             const likeStr = this.createLikeStr(keyOption.cs);
-            const keywords = StrUtil.toHalf(keyword).trim().split(' ');
+            const keywords = StrUtil.toDBStr(keyword, this.config.getConfig().convertTwoByteToOneByte).trim().split(' ');
             const keywordCnt = keywords.length;
 
             keywords.forEach((str, i) => {

--- a/src/server/Model/DB/RecordedDB.ts
+++ b/src/server/Model/DB/RecordedDB.ts
@@ -689,7 +689,7 @@ abstract class RecordedDB extends DBTableBase implements RecordedDBInterface {
         }
 
         if (typeof option.keyword !== 'undefined') {
-            const keyword = this.config.getConfig().convertTwoByteToOneByte ? StrUtil.toHalf(option.keyword) : option.keyword;
+            const keyword = StrUtil.toDBStr(option.keyword, this.config.getConfig().convertTwoByteToOneByte);
             // tslint:disable-next-line:no-irregular-whitespace
             keyword.trim().split(/ |　/).forEach((s) => {
                 s = `%${ s }%`;

--- a/src/server/Model/DB/RecordedDB.ts
+++ b/src/server/Model/DB/RecordedDB.ts
@@ -689,7 +689,9 @@ abstract class RecordedDB extends DBTableBase implements RecordedDBInterface {
         }
 
         if (typeof option.keyword !== 'undefined') {
-            StrUtil.toHalf(option.keyword).trim().split(' ').forEach((s) => {
+            const keyword = this.config.getConfig().convertTwoByteToOneByte ? StrUtil.toHalf(option.keyword) : option.keyword;
+            // tslint:disable-next-line:no-irregular-whitespace
+            keyword.trim().split(/ |　/).forEach((s) => {
                 s = `%${ s }%`;
                 const nameStr = `${ this.operator.createValueStr(values.length + 1, values.length + 1) }`;
                 values.push(s);

--- a/src/server/Util/StrUtil.ts
+++ b/src/server/Util/StrUtil.ts
@@ -4,13 +4,14 @@
 namespace StrUtil {
     /**
      * 文字列をデータベース用文字列に変換する．
-     * convertTwoByteToOneByteがtrueの場合は全角英数記号を半角へ変換する
+     * convertTwoByteToOneByteがundefinedあるいはtrueの場合は全角英数記号を半角へ変換する
      * @param str: string
      * @param convertTwoByteToOneByte: boolean
      * @return string
      */
-    export const toDBStr = (str: string, convertTwoByteToOneByte: boolean): string => {
-      const ret = convertTwoByteToOneByte ? toHalf(str) : str;
+    export const toDBStr = (str: string, convertTwoByteToOneByte: boolean | undefined): string => {
+      const convertCond = convertTwoByteToOneByte === undefined ? true : convertTwoByteToOneByte;
+      const ret = convertCond ? toHalf(str) : str;
 
       return ret.replace(/\x00/g, ''); // PostgreSQL 非対応文字
     };

--- a/src/server/Util/StrUtil.ts
+++ b/src/server/Util/StrUtil.ts
@@ -3,6 +3,19 @@
  */
 namespace StrUtil {
     /**
+     * 文字列をデータベース用文字列に変換する．
+     * convertTwoByteToOneByteがtrueの場合は全角英数記号を半角へ変換する
+     * @param str: string
+     * @param convertTwoByteToOneByte: boolean
+     * @return string
+     */
+    export const toDBStr = (str: string, convertTwoByteToOneByte: boolean): string => {
+      const ret = convertTwoByteToOneByte ? toHalf(str) : str;
+
+      return ret.replace(/\x00/g, ''); // PostgreSQL 非対応文字
+    };
+
+    /**
      * 全角英数記号を半角へ変換する
      * @param str: string
      * @return string
@@ -18,8 +31,7 @@ namespace StrUtil {
             .replace(/￥/g, '\\')
             // tslint:disable-next-line:no-irregular-whitespace
             .replace(/　/g, ' ')
-            .replace(/〜/g, '~')
-            .replace(/\x00/g, ''); // PostgreSQL 非対応文字
+            .replace(/〜/g, '~');
     };
 
     /**


### PR DESCRIPTION
## 概要(Summary)
いつも快適に利用させていただいています．
現状，EPGStationでは番組名や概要の全角英数字は半角に変換されますが，
!や~などの一部記号が私物のスクリプトでの処理とぶつかるなどあり，
オプションでこれらを半角にする/しないを選べると便利と思いアップデートしました．

また，`StrUtil`の`toHalf`内にデータベース向けと思われる置き換え(`\x00`の削除)があったため，
データベース用に文字列を変換するメソッドを作成し半角変換でない部分をそちらで処理するよう変更しました．

### 変更点
- `config.json`に`convertTwoByteToOneByte`オプションを追加
  - `true`の場合半角に変換，`false`の場合変換しない
  - デフォルトは`true`
- 文字列をデータベース用に変換するメソッド`toDBStr`を`StrUtil`に追加
  - toHalfに含まれていた`\x00`の処理を`toDBStr`で行うように変更
  - 引数`convertTwoByteToOneByte`が`undefined`または`true`の場合`toHalf`を行う
- データベースに関係するメソッド中で`toHalf`を呼んでいるものを`toDBStr`を呼ぶように変更
  - `toHalf`は全てデータベースに関係するメソッド中に呼ばれていたので，結果として全ての`toHalf`が`toDBStr`に置き換えられています．
- `conf-manual.md`に`convertTwoByteToOneByte`の追加

### 動作確認環境
- サーバサイド
  - Version of EPGStation: update from `1.2.7`
  - Version of Mirakurun: `2.7.5`
  - Version of Node: `v8.11.3`
  - Version of NPM: `6.5.0`
  - OS: CentOS 7.2
  - Architecture: x64
  - Database: MariaDB 5.5.6
- クライアントサイド
  - OS: macOS High Sierra 10.13.6
  - Browser: Google Chrome 70.0.3538.110
 
### 動作確認
- `config.json`に`"convertTwoByteToOneByte": true`を追加し
  - `Programs`の`name`,`shortName`,`description`,`extended`内の英数字記号が半角に変換されていることを確認
  - ブラウザより，この状態で録画した番組が半角英数字記号で検索できることを確認
- `config.json`に`"convertTwoByteToOneByte": false`を追加し
  - `Programs`の`name`,`shortName`,`description`,`extended`内の英数字記号が全角のままであることを確認
  - ブラウザより，この状態で録画した番組が全角英数字記号で検索できることを確認
- `config.json`に`"convertTwoByteToOneByte"`を削除し
  - `Programs`の`name`,`shortName`,`description`,`extended`内の英数字記号が半角に変換されていることを確認
  - ブラウザより，この状態で録画した番組が半角英数字記号で検索できることを確認

少し粒度が大きく，かつ影響を与える部分が大きいPRになりますが，
ご考慮いただけると幸いです．