### PR TITLE
ライブ一覧画面のUI改善

### DIFF
--- a/src/client/Component/Stream/StreamProgramCardsComponent.ts
+++ b/src/client/Component/Stream/StreamProgramCardsComponent.ts
@@ -5,6 +5,7 @@ import DateUtil from '../../Util/DateUtil';
 import Util from '../../Util/Util';
 import BalloonViewModel from '../../ViewModel/Balloon/BalloonViewModel';
 import MainLayoutViewModel from '../../ViewModel/MainLayoutViewModel';
+import ProgramInfoViewModel from '../../ViewModel/Program/ProgramInfoViewModel';
 import StreamProgramCardsViewModel from '../../ViewModel/Stream/StreamProgramCardsViewModel';
 import StreamSelectViewModel from '../../ViewModel/Stream/StreamSelectViewModel';
 import factory from '../../ViewModel/ViewModelFactory';
@@ -25,6 +26,7 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
     private viewModel: StreamProgramCardsViewModel;
     private mainLayoutViewModel: MainLayoutViewModel;
     private selectorViewModel: StreamSelectViewModel;
+    private infoViewModel: ProgramInfoViewModel;
     private balloon: BalloonViewModel;
     private contentElement: HTMLElement;
     private isDoneInit: boolean = false;
@@ -34,6 +36,7 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
         this.viewModel = <StreamProgramCardsViewModel> factory.get('StreamProgramCardsViewModel');
         this.mainLayoutViewModel = <MainLayoutViewModel> factory.get('MainLayoutViewModel');
         this.selectorViewModel = <StreamSelectViewModel> factory.get('StreamSelectViewModel');
+        this.infoViewModel = <ProgramInfoViewModel> factory.get('ProgramInfoViewModel');
         this.balloon = <BalloonViewModel> factory.get('BalloonViewModel');
     }
 
@@ -117,11 +120,18 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
         return m('div', {
             class: 'mdl-card__supporting-text',
             onclick: (e: Event) => {
-                this.selectorViewModel.set(item.channel);
-                this.balloon.open(StreamSelectViewModel.id, e);
+                this.infoViewModel.set(item.programs[0], item.channel);
+                this.balloon.open(ProgramInfoViewModel.id, e);
             },
         }, [
-            m('div', { class: 'name' }, item.channel.name),
+            m('div', {
+                class: 'name',
+                onclick: (e: Event) => {
+                    e.stopPropagation();
+                    this.selectorViewModel.set(item.channel);
+                    this.balloon.open(StreamSelectViewModel.id, e);
+                },
+            }, item.channel.name),
             m('div', { class: 'time' }, this.createTimeStr(item.programs[0])),
             m('div', { class: 'title' }, item.programs[0].name),
             m('div', { class: 'description' }, item.programs[0].description),

--- a/src/client/Component/Stream/StreamProgramCardsComponent.ts
+++ b/src/client/Component/Stream/StreamProgramCardsComponent.ts
@@ -128,16 +128,16 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
         return m('div', {
             class: 'mdl-card__supporting-text',
             onclick: (e: Event) => {
-                this.infoViewModel.set(item.programs[0], item.channel);
-                this.balloon.open(ProgramInfoViewModel.id, e);
+                this.selectorViewModel.set(item.channel);
+                this.balloon.open(StreamSelectViewModel.id, e);
             },
         }, [
             m('div', {
                 class: 'name',
                 onclick: (e: Event) => {
                     e.stopPropagation();
-                    this.selectorViewModel.set(item.channel);
-                    this.balloon.open(StreamSelectViewModel.id, e);
+                    this.infoViewModel.set(item.programs[0], item.channel);
+                    this.balloon.open(ProgramInfoViewModel.id, e);
                 },
             }, item.channel.name),
             m('div', { class: 'time' }, this.createTimeStr(item.programs[0])),

--- a/src/client/Component/Stream/StreamProgramCardsComponent.ts
+++ b/src/client/Component/Stream/StreamProgramCardsComponent.ts
@@ -1,6 +1,7 @@
 import { throttle } from 'lodash';
 import * as m from 'mithril';
 import * as apid from '../../../../api';
+import { AllReserves } from '../../Model/Api/ReservesApiModel';
 import DateUtil from '../../Util/DateUtil';
 import Util from '../../Util/Util';
 import BalloonViewModel from '../../ViewModel/Balloon/BalloonViewModel';
@@ -29,6 +30,7 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
     private infoViewModel: ProgramInfoViewModel;
     private balloon: BalloonViewModel;
     private contentElement: HTMLElement;
+    private allReserves: AllReserves | null;
     private isDoneInit: boolean = false;
 
     constructor() {
@@ -61,6 +63,9 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
      */
     public view(mainVnode: m.Vnode<StramCardArgs, this>): m.Child {
         const broadcasts = this.viewModel.getBroadcastList();
+
+        // 予約情報を取得
+        this.allReserves = this.viewModel.getReserves();
 
         return m('div', {
             class: 'stream-programs-cards main-layout-animation',
@@ -102,7 +107,12 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
                 },
             }, [
                 this.viewModel.getPrograms(broadcasts[this.viewModel.getTabPosition()]).map((item) => {
-                    return m('div', { class: 'mdl-card mdl-shadow--2dp mdl-cell mdl-cell--12-col' },
+                    let baseClass = 'mdl-card mdl-shadow--2dp mdl-cell mdl-cell--12-col';
+                    if (this.allReserves && this.allReserves[item.programs[0].id]) {
+                        baseClass += ' mdl-card__is-recording';
+                    }
+
+                    return m('div', { class: baseClass },
                         this.createContent(item),
                     );
                 }),

--- a/src/client/Component/Stream/StreamProgramCardsComponent.ts
+++ b/src/client/Component/Stream/StreamProgramCardsComponent.ts
@@ -1,7 +1,6 @@
 import { throttle } from 'lodash';
 import * as m from 'mithril';
 import * as apid from '../../../../api';
-import { AllReserves } from '../../Model/Api/ReservesApiModel';
 import DateUtil from '../../Util/DateUtil';
 import Util from '../../Util/Util';
 import BalloonViewModel from '../../ViewModel/Balloon/BalloonViewModel';
@@ -30,7 +29,6 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
     private infoViewModel: ProgramInfoViewModel;
     private balloon: BalloonViewModel;
     private contentElement: HTMLElement;
-    private allReserves: AllReserves | null;
     private isDoneInit: boolean = false;
 
     constructor() {
@@ -65,7 +63,7 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
         const broadcasts = this.viewModel.getBroadcastList();
 
         // 予約情報を取得
-        this.allReserves = this.viewModel.getReserves();
+        const reserves = this.viewModel.getReserves();
 
         return m('div', {
             class: 'stream-programs-cards main-layout-animation',
@@ -108,7 +106,7 @@ class StreamProgramCardsComponent extends Component<StramCardArgs> {
             }, [
                 this.viewModel.getPrograms(broadcasts[this.viewModel.getTabPosition()]).map((item) => {
                     let baseClass = 'mdl-card mdl-shadow--2dp mdl-cell mdl-cell--12-col';
-                    if (this.allReserves && this.allReserves[item.programs[0].id]) {
+                    if (reserves !== null && typeof reserves[item.programs[0].id] !== 'undefined') {
                         baseClass += ' mdl-card__is-recording';
                     }
 

--- a/src/client/Component/Stream/StreamProgramComponent.ts
+++ b/src/client/Component/Stream/StreamProgramComponent.ts
@@ -1,6 +1,7 @@
 import * as m from 'mithril';
 import { ViewModelStatus } from '../../Enums';
 import BalloonViewModel from '../../ViewModel/Balloon/BalloonViewModel';
+import ProgramInfoViewModel from '../../ViewModel/Program/ProgramInfoViewModel';
 import StreamForcedStopViewModel from '../../ViewModel/Stream/StreamForcedStopViewModel';
 import StreamLivePlayerViewModel from '../../ViewModel/Stream/StreamLivePlayerViewModel';
 import StreamProgramCardsViewModel from '../../ViewModel/Stream/StreamProgramCardsViewModel';
@@ -9,6 +10,8 @@ import factory from '../../ViewModel/ViewModelFactory';
 import { BalloonComponent } from '../BalloonComponent';
 import MainLayoutComponent from '../MainLayoutComponent';
 import ParentComponent from '../ParentComponent';
+import ProgramInfoActionComponent from '../Program/ProgramInfoActionComponent';
+import ProgramInfoComponent from '../Program/ProgramInfoComponent';
 import StreamLivePlayerComponent from './StreamLivePlayerComponent';
 import StreamProgramCardsComponent from './StreamProgramCardsComponent';
 import StreamProgramTimeComponent from './StreamProgramTimeComponent';
@@ -79,6 +82,14 @@ class StreamProgramComponent extends ParentComponent<void> {
                     content: m(StreamSelectComponent),
                     maxWidth: 400,
                     forceDialog: window.innerHeight < 480,
+                }),
+                m(BalloonComponent, {
+                    id: ProgramInfoViewModel.id,
+                    content: m(ProgramInfoComponent),
+                    action: m(ProgramInfoActionComponent),
+                    maxWidth: 500,
+                    maxHeight: 450,
+                    dialogMaxWidth: 600,
                 }),
                 m(BalloonComponent, {
                     id: StreamLivePlayerViewModel.id,

--- a/src/client/ViewModel/Stream/StreamProgramCardsViewModel.ts
+++ b/src/client/ViewModel/Stream/StreamProgramCardsViewModel.ts
@@ -1,6 +1,7 @@
 import * as apid from '../../../../api';
 import { ViewModelStatus } from '../../Enums';
 import { ConfigApiModelInterface } from '../../Model/Api/ConfigApiModel';
+import { AllReserves, ReservesApiModelInterface } from '../../Model/Api/ReservesApiModel';
 import { ScheduleApiModelInterface } from '../../Model/Api/ScheduleApiModel';
 import { TabModelInterface } from '../../Model/Tab/TabModel';
 import ViewModel from '../ViewModel';
@@ -10,19 +11,23 @@ import ViewModel from '../ViewModel';
  */
 class StreamProgramCardsViewModel extends ViewModel {
     private scheduleApiModel: ScheduleApiModelInterface;
+    private reservesApiModel: ReservesApiModelInterface;
     private tab: TabModelInterface;
     private configApiModel: ConfigApiModelInterface;
     private timer: number | null = null;
+    private reserves: AllReserves | null = null;
 
     public additionTime: number = 0;
 
     constructor(
         scheduleApiModel: ScheduleApiModelInterface,
+        reservesApiModel: ReservesApiModelInterface,
         tab: TabModelInterface,
         configApiModel: ConfigApiModelInterface,
     ) {
         super();
         this.scheduleApiModel = scheduleApiModel;
+        this.reservesApiModel = reservesApiModel;
         this.tab = tab;
         this.configApiModel = configApiModel;
     }
@@ -35,10 +40,12 @@ class StreamProgramCardsViewModel extends ViewModel {
 
         if (status === 'init') {
             this.additionTime = 0;
+            this.reservesApiModel.init();
             this.scheduleApiModel.init();
         }
 
         await this.updateProgram();
+        await this.updateReserves();
     }
 
     /**
@@ -69,6 +76,13 @@ class StreamProgramCardsViewModel extends ViewModel {
         this.timer = window.setTimeout(() => {
             this.updateProgram();
         }, minEndTime);
+    }
+
+    /**
+     * 予約された program id を取得する
+     */
+    private async updateReserves(): Promise<void> {
+        this.reserves = await this.reservesApiModel.fetchAllId();
     }
 
     /**
@@ -145,6 +159,14 @@ class StreamProgramCardsViewModel extends ViewModel {
     public async resetTime(): Promise<void> {
         this.additionTime = 0;
         await this.updateProgram();
+    }
+
+    /**
+     * getReserves
+     * @return AllReserves
+     */
+    public getReserves(): AllReserves | null {
+        return this.reserves;
     }
 }
 

--- a/src/client/ViewModel/Stream/StreamProgramCardsViewModel.ts
+++ b/src/client/ViewModel/Stream/StreamProgramCardsViewModel.ts
@@ -15,7 +15,6 @@ class StreamProgramCardsViewModel extends ViewModel {
     private tab: TabModelInterface;
     private configApiModel: ConfigApiModelInterface;
     private timer: number | null = null;
-    private reserves: AllReserves | null = null;
 
     public additionTime: number = 0;
 
@@ -82,7 +81,7 @@ class StreamProgramCardsViewModel extends ViewModel {
      * 予約された program id を取得する
      */
     private async updateReserves(): Promise<void> {
-        this.reserves = await this.reservesApiModel.fetchAllId();
+        await this.reservesApiModel.fetchAllId();
     }
 
     /**
@@ -100,6 +99,14 @@ class StreamProgramCardsViewModel extends ViewModel {
         });
 
         return results;
+    }
+
+    /**
+     * getReserves
+     * @return AllReserves
+     */
+    public getReserves(): AllReserves | null {
+        return this.reservesApiModel.getAllId();
     }
 
     /**
@@ -159,14 +166,6 @@ class StreamProgramCardsViewModel extends ViewModel {
     public async resetTime(): Promise<void> {
         this.additionTime = 0;
         await this.updateProgram();
-    }
-
-    /**
-     * getReserves
-     * @return AllReserves
-     */
-    public getReserves(): AllReserves | null {
-        return this.reserves;
     }
 }
 

--- a/src/client/ViewModel/ViewModelFactorySetting.ts
+++ b/src/client/ViewModel/ViewModelFactorySetting.ts
@@ -261,6 +261,7 @@ namespace ViewModelFactorySetting {
         ));
         factory.reg('StreamProgramCardsViewModel', new StreamProgramCardsViewModel(
             scheduleApiModel,
+            reservesApiModel,
             tabModel,
             configModel,
         ));

--- a/src/css/stream-program-cards.sass
+++ b/src/css/stream-program-cards.sass
@@ -21,8 +21,11 @@
                     pointer-events: none;
                 .name
                     font-weight: bold;
-                    font-size: 16px;
+                    font-size: 18px;
                     margin-bottom: 4px;
+                    color: #6c80ef;
+                    cursor: pointer;
+                    pointer-events: initial;
                 .time
                     font-size: 12px;
                 .title

--- a/src/css/stream-program-cards.sass
+++ b/src/css/stream-program-cards.sass
@@ -36,3 +36,6 @@
                 .description
                     font-size: 13px;
 
+        .mdl-card__is-recording
+            border: 3px solid red;
+

--- a/src/css/stream-program-cards.sass
+++ b/src/css/stream-program-cards.sass
@@ -21,11 +21,12 @@
                     pointer-events: none;
                 .name
                     font-weight: bold;
-                    font-size: 18px;
+                    font-size: 16px;
                     margin-bottom: 4px;
                     color: #6c80ef;
                     cursor: pointer;
                     pointer-events: initial;
+                    display: inline-block;
                 .time
                     font-size: 12px;
                 .title


### PR DESCRIPTION
## 概要(Summary)

- Fixed #204 
- ライブ画面から番組詳細閲覧や予約をできるようにしました
- ライブ画面のチャンネル名を少し大きくして色を変えて別々に押せることをわかりやすくしました
- 録画中（予約済み）の番組を赤枠で強調表示するようにしました

いつもお世話になっております。
以前立てたIssueを自分で実装してみましたが、あまりコードが理解できていないので自信がありません。
一通り動作は確認しております。
録画中の番組を一番上に持ってくる機能はあまり需要がないかと思ったので強調表示だけにしました。
以上お手数ですがよろしくお願いいたします。

