### PR TITLE
ルールページに「ルール追加」ボタンを追加

### DIFF
--- a/doc/windows.md
+++ b/doc/windows.md
@@ -108,7 +108,7 @@ unix 系では `/` を使用するため *.sample.json では `/hoge/huga/piyo` 
 ### config.json
 #### encode
 
-[enc.sh](../config/enc.sh) を起動するようになっていますが、 Windows では動作しないため `config/enc.js` へ書き換えでください
+[enc.sh](../config/enc.sh) を起動するようになっていますが、 Windows では動作しないため `config/enc.js` へ書き換えてください
 
 ```
 "cmd": "C:\\PROGRA~1\\nodejs\\node.exe %ROOT%\\config\\enc.js main"

--- a/src/client/Component/Rules/RulesComponent.ts
+++ b/src/client/Component/Rules/RulesComponent.ts
@@ -154,6 +154,21 @@ class RulesComponent extends ParentComponent<void> {
                 length: this.viewModel.getLimit(),
                 page: this.viewModel.getPage(),
             }),
+            this.createAddButton(),
+        ]);
+    }
+
+    /**
+     * ルール追加ボタン
+     */
+    private createAddButton(): m.Child {
+        return m('button', {
+            class: 'fab-right-bottom mdl-shadow--8dp mdl-button mdl-js-button mdl-button--fab mdl-button--colored',
+            onclick: () => {
+                Util.move('/search');
+            },
+        }, [
+            m('i', { class: 'material-icons' }, 'playlist_add'),
         ]);
     }
 


### PR DESCRIPTION
## 概要(Summary)
- doc/windows.md の誤字を修正 ( 書き換え **で** ください -> 書き換え **て** ください  )
- Issues #232 にて提起された **ルールページからルールの作成が出来ない** 問題の暫定的対処として、ルール追加ボタンをフローティングボタンとして表示。
実際にはフローティングボタンはリンク先として /search に飛ぶだけ。
![image](https://user-images.githubusercontent.com/9246266/52856576-2c3bff00-3168-11e9-9c52-f5370309ee22.png)