### PR TITLE
HLSにおいて字幕再生機能を追加

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -50,29 +50,29 @@
     "recordedHLS": [
         {
             "name": "1280x720(main)",
-            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "720x480(main)",
-            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "720x480(h265-main)",
-            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_type fmp4 -hls_fmp4_init_filename stream%streamNum%-init.mp4 -hls_segment_filename stream%streamNum%-%09d.m4s -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx265 -s 720x480 -preset veryfast -aspect 16:9 -vb 350k -tag:v hvc1 %OUTPUT%"
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_type fmp4 -hls_fmp4_init_filename stream%streamNum%-init.mp4 -hls_segment_filename stream%streamNum%-%09d.m4s -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx265 -s 720x480 -preset veryfast -aspect 16:9 -vb 350k -tag:v hvc1 %OUTPUT%"
         }
     ],
     "liveHLS": [
         {
             "name": "1280x720(main)",
-            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "720x480(main)",
-            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "320x180(main)",
-            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 48k -ac 2 -c:v libx264 -s 320x180 -preset veryfast -aspect 16:9 -vb 100k -maxrate 110k -bufsize 1000k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 48k -ac 2 -c:v libx264 -s 320x180 -preset veryfast -aspect 16:9 -vb 100k -maxrate 110k -bufsize 1000k -flags +loop-global_header %OUTPUT%"
         }
     ],
     "liveWebM": [

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -50,29 +50,29 @@
     "recordedHLS": [
         {
             "name": "1280x720(main)",
-            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0 -ignore_unknown -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "720x480(main)",
-            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0 -ignore_unknown -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "720x480(h265-main)",
-            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_type fmp4 -hls_fmp4_init_filename stream%streamNum%-init.mp4 -hls_segment_filename stream%streamNum%-%09d.m4s -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx265 -s 720x480 -preset veryfast -aspect 16:9 -vb 350k -tag:v hvc1 %OUTPUT%"
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0 -ignore_unknown -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_type fmp4 -hls_fmp4_init_filename stream%streamNum%-init.mp4 -hls_segment_filename stream%streamNum%-%09d.m4s -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx265 -s 720x480 -preset veryfast -aspect 16:9 -vb 350k -tag:v hvc1 %OUTPUT%"
         }
     ],
     "liveHLS": [
         {
             "name": "1280x720(main)",
-            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0 -ignore_unknown -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v libx264 -s 1280x720 -preset veryfast -aspect 16:9 -vb 3000k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "720x480(main)",
-            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0 -ignore_unknown -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v libx264 -s 720x480 -preset veryfast -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
         },
         {
             "name": "320x180(main)",
-            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 48k -ac 2 -c:v libx264 -s 320x180 -preset veryfast -aspect 16:9 -vb 100k -maxrate 110k -bufsize 1000k -flags +loop-global_header %OUTPUT%"
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -map 0 -ignore_unknown -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 48k -ac 2 -c:v libx264 -s 320x180 -preset veryfast -aspect 16:9 -vb 100k -maxrate 110k -bufsize 1000k -flags +loop-global_header %OUTPUT%"
         }
     ],
     "liveWebM": [

--- a/config/enc.sh
+++ b/config/enc.sh
@@ -11,8 +11,8 @@ function getHeight() {
 }
 
 if [ `getHeight` -gt 720 ]; then
-    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 1280x720 -c:a aac -ar 48000 -ab 192k -ac 2 "$OUTPUT"
+    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -map 0 -ignore_unknown -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 1280x720 -c:a aac -ar 48000 -ab 192k -ac 2 "$OUTPUT"
 else
-    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 720x480 -c:a aac -ar 48000 -ab 128k -ac 2 "$OUTPUT"
+    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -map 0 -ignore_unknown -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 720x480 -c:a aac -ar 48000 -ab 128k -ac 2 "$OUTPUT"
 fi
 

--- a/config/enc.sh
+++ b/config/enc.sh
@@ -11,8 +11,8 @@ function getHeight() {
 }
 
 if [ `getHeight` -gt 720 ]; then
-    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 1280x720 -c:a aac -ar 48000 -ab 192k -ac 2 "$OUTPUT"
+    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 1280x720 -c:a aac -ar 48000 -ab 192k -ac 2 "$OUTPUT"
 else
-    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 720x480 -c:a aac -ar 48000 -ab 128k -ac 2 "$OUTPUT"
+    $FFMPEG -dual_mono_mode $mode -i "$INPUT" -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1 -vf yadif -preset veryfast -c:v libx264 -crf 23 -f mp4 -s 720x480 -c:a aac -ar 48000 -ab 128k -ac 2 "$OUTPUT"
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -908,9 +908,9 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "b24.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/b24.js/-/b24.js-1.0.1.tgz",
-      "integrity": "sha512-s4pk+/fh/M6HXVwXc/FlbT+x8j66RmHXrk8WBNb61o9ApuoFq2yLOpgtRjvRXtm3LsiKMBjdMYTaVzqWYTe9AQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/b24.js/-/b24.js-1.0.2.tgz",
+      "integrity": "sha512-1nM6wlETflzjNDVueVIc4paKB3ArJ8cDOxm4uBFnsImyC9Y5XHCx8nu/kgxbNvp7lOwMXDJ5DvlIWu1/M7krHQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGStation",
-  "version": "1.3.9",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -812,7 +812,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -906,6 +906,11 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "b24.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/b24.js/-/b24.js-1.0.0.tgz",
+      "integrity": "sha512-0nFJzY1bWLeNlD5DI0wbugl3qd1Nj+RcEyx26n6sO08A+G3qBLpCg7yhzD0QmWqb2rwnlVDhIo2/j/iyPI/4nQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1160,7 +1165,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1197,7 +1202,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1800,7 +1805,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -1813,7 +1818,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2162,7 +2167,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3615,7 +3620,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -3741,7 +3746,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -3916,7 +3921,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         },
@@ -4285,6 +4290,22 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hls-b24.js": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/hls-b24.js/-/hls-b24.js-0.12.3.tgz",
+      "integrity": "sha512-C8nwzS33zKvR7grYIoHvp8wPxBvk9sEJ6dsh3Bx+T/4jNNhDksqLS73NIWqHvInjRiOsrXgEY4+h/NjNbzzh0g==",
+      "requires": {
+        "eventemitter3": "3.1.0",
+        "url-toolkit": "^2.1.6"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+        }
       }
     },
     "hls.js": {
@@ -5303,18 +5324,18 @@
       }
     },
     "mirakurun": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/mirakurun/-/mirakurun-2.8.3.tgz",
-      "integrity": "sha512-CH0b3bFnHuhBUKDKLEXlQaRMq8Ll47h5DgxdEZ/X9cqCwUj2nRPYUj8LbFFVBFS2APO3CC+xYMB3Z+B/OEC8Pw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/mirakurun/-/mirakurun-2.8.4.tgz",
+      "integrity": "sha512-8Pb+RGwTnlg+7toHmHkvGYg6eV17dAxMPQGdkFKPSmmXsW8FFtUElqSFft8I6R/7koXO1+MPC0u7gAuYWHvdag==",
       "requires": {
         "aribts": "^1.3.4",
         "body-parser": "^1.18.3",
         "colors": "^1.3.3",
-        "dotenv": "^6.1.0",
+        "dotenv": "^6.2.0",
         "express": "^4.16.4",
-        "express-openapi": "^3.6.0",
+        "express-openapi": "^3.7.0",
         "ip": "^1.1.4",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.12.1",
         "latest-version": "^3.1.0",
         "morgan": "^1.9.1",
         "munin-plugin": "0.0.9",
@@ -5660,7 +5681,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
@@ -5935,9 +5956,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -7080,7 +7101,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -7090,7 +7111,7 @@
     },
     "sift": {
       "version": "5.1.0",
-      "resolved": "http://registry.npmjs.org/sift/-/sift-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-5.1.0.tgz",
       "integrity": "sha1-G78t+w63HlbEzH+1Z/vRNRtlAV4="
     },
     "signal-exit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,7 +812,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -908,9 +908,9 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "b24.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/b24.js/-/b24.js-1.0.0.tgz",
-      "integrity": "sha512-0nFJzY1bWLeNlD5DI0wbugl3qd1Nj+RcEyx26n6sO08A+G3qBLpCg7yhzD0QmWqb2rwnlVDhIo2/j/iyPI/4nQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/b24.js/-/b24.js-1.0.1.tgz",
+      "integrity": "sha512-s4pk+/fh/M6HXVwXc/FlbT+x8j66RmHXrk8WBNb61o9ApuoFq2yLOpgtRjvRXtm3LsiKMBjdMYTaVzqWYTe9AQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1165,7 +1165,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1202,7 +1202,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1805,7 +1805,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -1818,7 +1818,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2167,7 +2167,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3000,7 +3000,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3024,13 +3025,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3047,19 +3050,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3190,7 +3196,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3204,6 +3211,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3220,6 +3228,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3228,13 +3237,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3255,6 +3266,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3343,7 +3355,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3357,6 +3370,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3452,7 +3466,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3494,6 +3509,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3515,6 +3531,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3563,13 +3580,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3620,7 +3639,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -3746,7 +3765,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -3921,7 +3940,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         },
@@ -4296,22 +4315,6 @@
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/hls-b24.js/-/hls-b24.js-0.12.3.tgz",
       "integrity": "sha512-C8nwzS33zKvR7grYIoHvp8wPxBvk9sEJ6dsh3Bx+T/4jNNhDksqLS73NIWqHvInjRiOsrXgEY4+h/NjNbzzh0g==",
-      "requires": {
-        "eventemitter3": "3.1.0",
-        "url-toolkit": "^2.1.6"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
-        }
-      }
-    },
-    "hls.js": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.12.2.tgz",
-      "integrity": "sha512-lQBSXggw9OzEuaUllUBoSxPcf7neFgnEiDRfCdCNdIPtUeV7vXZ0OeASx6EWtZTBiqSSPigoOX1Y+AR5dA1Feg==",
       "requires": {
         "eventemitter3": "3.1.0",
         "url-toolkit": "^2.1.6"
@@ -5681,7 +5684,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
@@ -7101,7 +7104,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -7111,7 +7114,7 @@
     },
     "sift": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-5.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/sift/-/sift-5.1.0.tgz",
       "integrity": "sha1-G78t+w63HlbEzH+1Z/vRNRtlAV4="
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "aribts": "^2.1.12",
+    "b24.js": "1.0.0",
     "basic-auth": "2.0.1",
     "body-parser": "1.18.3",
     "chart.js": "2.7.3",
@@ -41,7 +42,7 @@
     "express-ipfilter": "0.3.1",
     "express-openapi": "4.1.2",
     "fs-extra": "7.0.1",
-    "hls.js": "0.12.2",
+    "hls-b24.js": "0.12.3",
     "js-yaml": "3.12.1",
     "lodash": "4.17.11",
     "log4js": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "aribts": "^2.1.12",
-    "b24.js": "1.0.0",
+    "b24.js": "1.0.1",
     "basic-auth": "2.0.1",
     "body-parser": "1.18.3",
     "chart.js": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "aribts": "^2.1.12",
-    "b24.js": "1.0.1",
+    "b24.js": "1.0.2",
     "basic-auth": "2.0.1",
     "body-parser": "1.18.3",
     "chart.js": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/server/index.js",
     "dev-start": "node dist/server/index.js --env development",
     "clean": "gulp clean",
-    "build": "gulp build --max_old_space_size=512 --env production",
+    "build": "gulp build --max_old_space_size=768 --env production",
     "dev-build": "gulp build --max_old_space_size=512 --env development",
     "test": "echo \"Error: no test specified\" && exit 1",
     "task": "gulp --max_old_space_size=512",

--- a/src/client/Component/Stream/StreamWatchVideoComponent.ts
+++ b/src/client/Component/Stream/StreamWatchVideoComponent.ts
@@ -120,9 +120,7 @@ class StreamWatchVideoComponent extends Component<void> {
      * create B24 subtitle renderer
      */
     private createB24Renderer(element: HTMLVideoElement, hls: Hls): void {
-        if (!Hls.isSupported()) {
-            return;
-        }
+        if (hls === null) { return; }
 
         this.b24Renderer = new b24js.WebVTTRenderer();
         this.b24Renderer.init().then(() => {

--- a/src/client/Component/Stream/StreamWatchVideoComponent.ts
+++ b/src/client/Component/Stream/StreamWatchVideoComponent.ts
@@ -101,7 +101,8 @@ class StreamWatchVideoComponent extends Component<void> {
      * create hls
      */
     private createHls(element: HTMLVideoElement): void {
-        if (!Hls.isSupported() || Util.uaIsiOS() || Util.uaIsSafari()) { return; }
+        // macOS Safari 10+ において hls.js にする
+        if (!Hls.isSupported() || (Util.uaIsSafari() && !Util.uaIsSafari10OrLater()) || Util.uaIsiOS()) { return; }
 
         this.hls = new Hls();
         this.hls.loadSource(this.videoSrc);

--- a/src/client/Util/Util.ts
+++ b/src/client/Util/Util.ts
@@ -131,6 +131,14 @@ namespace Util {
     };
 
     /**
+     * UA が Safari 10+ か判定
+     * @return boolean
+     */
+    export const uaIsSafari10OrLater = (): boolean => {
+        return uaIsSafari() && (/Version\/1\d/i).test(navigator.userAgent);
+    };
+
+    /**
      * UA が Mobile か判定
      * @return boolean
      */


### PR DESCRIPTION
## 概要

hls.js streamingにおいてARIB B24のデジタル字幕を同時に再生できるようになりました。これにより、日本語の聞き取りが不自由の方にとって役立つと思います。

現在、Chrome・FireFox・Safari・Edgeで大体安定的に動作できています。

## 開発経緯

### 0x01
FFmpegがtranscoding際には、ディフォルトとして映像と音声のみを処理します。字幕データを抽出するために、`-map`オプションを追加して字幕データを出力にします。
```bash
%FFMPEG% -dual_mono_mode main -i %INPUT% -map 0:v:0 -map 0:a:0 -map 0:d:0 -map 0:d:1
```
これにより、映像と音声のほか、data streamリストの0番目ストリームと1番目ストリームを抽出します。なぜなら、1つprogramの中に字幕ストリームが2つあります。番組によって字幕が実際に使っているストリームが切り替える可能性があります。もしくは、FFmpegの内部に順番が替わる場合があります。そのため、2つストリームを全部抽出にします。（例えばNHKの場合は0x130・0x138というdata pidが存在）

### 0x02
hls.jsが動作するときに字幕データをmpegtsから分離し、callbackを提供することが必要になります。
実現するために自分のforkで改造を行いました。↓

https://github.com/xqq/hls.js/commits/hlsjs-b24

hls.jsへのpull requestは今検討中ですが、マージされるのは難しいと思います。

### 0x03
字幕レンダリングについては、まずhls.jsから提供されたバイナリデータをデコードする必要があります。TypeScriptでB24のparserを自作するのは面倒くさいだけではなく、車輪の再発明を避けるために、Emscriptenを用いて[aribb24](https://github.com/nkoriyama/aribb24)というCライブラリをHTML5にコンパイルして実行します。

JavaScriptでCコードを実行するのはおかしいと思われるかもしれないが、遅くなるわけではなく、むしろJavaScriptよりもっと高速になります。実行方式としてasm.jsまたはWebAssembly両方が可能、性能について大きな違いはありません。今度は利便性の考慮によりasm.jsにコンパイルしました。

そして得られた字幕データを用いて、WebVTTを生成するようにします。フォント色の表現はできています。Chromeで座標付きVTTCueの表現は未だ不安定ですので、現在は振り仮名を非表示にして、字幕データ中の座標に従うことを諦めました。

なお、WebVTT字幕の様式はブラウザによって若干違いがあります（EdgeではVTTCueが未実装で、backgroundが付いていない。FireFoxではCSSのフォント色指定が無視されている）

プロジェクトはこちら↓
https://github.com/xqq/b24.js

DIVとCSS3により精細的なレンダリングは可能ですが、時間の都合で今度は実装しませんでした。

## EPGStationへの統合について

改造したhls.js（hls-b24.js）とb24.jsは、npm packageにより入ってきました。今後も続いてhls-b24.jsをメンテナンスする予定です。

また、macOSのSafariにも字幕を再生させるため、Safari 10以上のバージョンにおいてhls.js+b24.jsの再生モードに変更しました。macOS Safari 10以前のバージョンではMSEが動作不良のためhls.jsが正しく動作できませんので、ブロックとなります。

gulpのパラメータについては、b24.jsのcmoduleを入ると、ビルドときにheap overflowがでてきました。それを解決するため、productionビルドでは512MBの指定から768MBに変更しました。

コントロールパネルでの字幕スイッチボタンは作っていません。必要があれば作って下さい。

バグや要望があれば教えてください。

## Screenshots

若干スクショをアップします。

![Snipaste_2019-03-10_19-08-51](https://user-images.githubusercontent.com/4645762/54088999-4f448200-43a7-11e9-9dca-56739f624d20.png)
![Snipaste_2019-03-10_19-10-11](https://user-images.githubusercontent.com/4645762/54089102-9f701400-43a8-11e9-8869-c0b4fa65c6d4.png)
Chrome

![image](https://user-images.githubusercontent.com/4645762/54089063-38eaf600-43a8-11e9-9eb0-0ad92c2acb91.png)
Safari
