### PR TITLE
`npm build`時のmax_old_space_sizeを512MBに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/server/index.js",
     "dev-start": "node dist/server/index.js --env development",
     "clean": "gulp clean",
-    "build": "gulp build --max_old_space_size=768 --env production",
+    "build": "gulp build --max_old_space_size=512 --env production",
     "dev-build": "gulp build --max_old_space_size=512 --env development",
     "test": "echo \"Error: no test specified\" && exit 1",
     "task": "gulp --max_old_space_size=512",


### PR DESCRIPTION
## 概要(Summary)

メモリが1GBの環境で`npm build`したときに発生するERR 137を回避するため．

Rock64 1GBで現象を確認済み．
