### PR TITLE
mkdir_streamFilePath

### DIFF
--- a/src/server/Util/Util.ts
+++ b/src/server/Util/Util.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 // tslint:disable-next-line:no-require-imports
 import urljoin = require('url-join');
@@ -83,7 +84,12 @@ namespace Util {
      * @return string
      */
     export const getStreamFilePath = (): string => {
-       return Configuration.getInstance().getConfig().streamFilePath || path.join(__dirname, '..', '..', '..', 'data', 'streamfiles');
+        const streamFilePath = Configuration.getInstance().getConfig().streamFilePath || path.join(__dirname, '..', '..', '..', 'data', 'streamfiles');
+        if (!fs.existsSync(streamFilePath)) {
+            fs.mkdirSync(streamFilePath);
+        }
+
+        return streamFilePath;
     };
 
     /**


### PR DESCRIPTION
## 概要(Summary)
"streamFilePath": "/tmp/hlsfile" 等を設定し、hlsfileフォルダが存在しない場合にHLS配信の開始が失敗する。
フォルダが存在しない場合は起動時にフォルダを作成するようにした。
