### PR TITLE
GitHub Actionsを使ったDockerイメージの自動ビルド

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+Dockerfile*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,152 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  # 現時点では、GitHub ActionsのWeb UIは、過去に実行したジョブの再実行はサポート
+  # しているが、指定したタグに対する実行などはサポートしていない。代替手段とし
+  # て、GitHub APIを使ったビルドの実行を可能とするよう、以下を設定しておく。
+  #
+  # 以下のようなスクリプトで、指定したタグのイメージを作成できる。
+  # ----------------------------------------------------------------------------
+  # REPO='l3tnun/EPGStation'
+  # GITHUB_TOKEN='token...'
+  # VERSION='1.6.8'
+  #
+  # JSON=$(cat <<EOF
+  # {
+  # "event_type": "build-docker-images",
+  # "client_payload": {
+  #    "ref": "$VERSION",  # ビルド対象のブランチ、タグ、またはコミットハッシュ
+  #    "latest": true      # latestタグ系を更新するかどうか
+  #  }
+  # }
+  # EOF
+  # )
+  #
+  # echo "$JSON" | curl https://api.github.com/repos/$REPO/dispatches \
+  #   -X POST -d @- \
+  #   -H "Authorization: token $GITHUB_TOKEN" \
+  #   -H "Content-Type: application/json"
+  # ----------------------------------------------------------------------------
+  repository_dispatch:
+    types:
+      - build-docker-images
+
+env:
+  DOCKER_BUILDKIT: 1
+  DOCKER_CLI_EXPERIMENTAL: enabled
+  MAIN_PLATFORM: debian
+
+jobs:
+  build-images:
+    # Fork先リポジトリーでは実行しない。
+    #
+    # 以下の条件では、`env.*`や`secrets.*`は使えない。
+    # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+    if: github.repository == 'l3tnun/EPGStation'
+    strategy:
+      matrix:
+        platform:
+          - alpine
+          - debian
+        arch:
+          # 公式のnodeイメージはarm32v6以前をサポートしていない
+          - amd64
+          - arm32v7
+          - arm64v8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set VERSION
+        run: |-
+          echo ::set-env name=VERSION::${GITHUB_REF#refs/*/}
+      - name: Checkout a specific src
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+        if: github.event_name == 'repository_dispatch'
+      - name: Override VERSION
+        run: |-
+          echo ::set-env name=VERSION::${{ github.event.client_payload.ref }}
+        if: github.event_name == 'repository_dispatch'
+      - name: Setup QEMU user-mode emulation
+        run: |-
+          sudo apt-get update
+          sudo apt-get install -y qemu qemu-user-static
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Build image
+        # 現時点では、`--squash`などの実験的機能はGitHub Actionsでは動かない
+        run: |-
+          docker build -t ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }} -f Dockerfile.${{ matrix.platform }} --no-cache --build-arg arch=${{ matrix.arch }} .
+      - name: Login to DockerHub
+        # DOCKERHUB_TOKENが登録されていない場合は、以下は失敗する
+        run: |-
+          docker login -u "${{ secrets.DOCKERHUB_USER }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
+      - name: Push image
+        run: |-
+          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }}
+      - name: Update latest tags for each platform
+        run: |-
+          docker tag ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-${{ matrix.arch }}
+          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-${{ matrix.arch }}
+        if: env.VERSION != 'master'
+      - name: Update the main platform tags
+        run: |-
+          docker tag ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.arch }}
+          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.arch }}
+        if: matrix.platform == env.MAIN_PLATFORM
+      - name: Update latest tags for the main platform
+        run: |-
+          docker tag ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-${{ matrix.arch }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.arch }}
+          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.arch }}
+        if: env.VERSION != 'master' && matrix.platform == env.MAIN_PLATFORM
+  build-multiarch-image:
+    strategy:
+      matrix:
+        platform:
+          - alpine
+          - debian
+    runs-on: ubuntu-latest
+    needs: build-images
+    steps:
+      - name: Set VERSION
+        run: |-
+          echo ::set-env name=VERSION::${GITHUB_REF#refs/*/}
+      - name: Override VERSION
+        run: |-
+          echo ::set-env name=VERSION::${{ github.event.client_payload.ref }}
+        if: github.event_name == 'repository_dispatch'
+      - name: Login to DockerHub
+        run: |-
+          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create and push the manifest for each platform
+        run: |-
+          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-amd64 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm64v8
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm32v7 --os linux --arch arm --variant v7
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm64v8 --os linux --arch arm64 --variant v8
+          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}
+      - name: Update latest tag for each platform
+        run: |-
+          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-amd64  ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm64v8
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm32v7 --os linux --arch arm --variant v7
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm64v8 --os linux --arch arm64 --variant v8
+          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}
+        if: env.VERSION != 'master'
+      - name: Update the version tag for the main platform
+        run: |-
+          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-amd64 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm64v8
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm32v7 --os linux --arch arm --variant v7
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8
+          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION
+        if: matrix.platform == env.MAIN_PLATFORM
+      - name: Update the latest tag for the main platform
+        run: |-
+          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }} ${{ secrets.DOCKERHUB_IMAGE }}:amd64 ${{ secrets.DOCKERHUB_IMAGE }}:arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:arm64v8
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }} ${{ secrets.DOCKERHUB_IMAGE }}:arm32v7 --os linux --arch arm --variant v7
+          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }} ${{ secrets.DOCKERHUB_IMAGE }}:arm64v8 --os linux --arch arm64 --variant v8
+          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}
+        if: env.VERSION != 'master' && matrix.platform == env.MAIN_PLATFORM

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,21 @@
+ARG arch=amd64
+
+FROM ${arch}/node:12-alpine AS builder
+
+RUN apk add --no-cache g++ make pkgconf python
+
+RUN mkdir -p /app
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build
+
+
+FROM ${arch}/node:12-alpine
+
+COPY --from=builder /app /app/
+
+EXPOSE 8888
+WORKDIR /app
+ENTRYPOINT ["npm"]
+CMD ["start"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,24 @@
+ARG arch=amd64
+
+FROM ${arch}/node:12-buster AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y build-essential python
+
+RUN mkdir -p /app
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build
+
+
+FROM ${arch}/node:12-buster-slim
+
+COPY --from=builder /app /app/
+
+EXPOSE 8888
+WORKDIR /app
+ENTRYPOINT ["npm"]
+CMD ["start"]


### PR DESCRIPTION
## 概要(Summary)

GitHub Actionsを使ってDockerイメージを自動でビルドするようにしました．

以下の条件でビルドを実行します．

* `master`ブランチへのプッシュ
* タグのプッシュ
* GitHub API `repository_dispatch`へのPOST

本PRをマージする前に，以下をSecretsに設定しておく必要があります．

* DOCKERHUB_IMAGE
  *プッシュ先Docker Hubのリポジトリー名（l3tnun/epgstationなど）
* DOCKERHUB_USER
  * Docker Hubのユーザー名（l3tnunなど）
* DOCKERHUB_TOKEN
  * Docker Hubで作成したトークン

Fork先では実行しないように条件を追加してあります．GitHub Actionsの制約のため，本リポジトリー名をリテラル文字列で記述しています．リポジトリー名を変更した場合は，この部分の変更する必要があります．

`ffmpeg`は含まれていません．利用するハードウェアやコーデックに依存してビルドする場合が多いためです．必要に応じて各自ビルド・インストールすることを想定しています．

### なぜDocker Hubの自動ビルドを使わないのか

最初はDocker Hubの自動ビルドを使おうとしましたが，multi-archイメージの作成に適していなかったので，GitHub Actionsに変更しました．

hooks/post_checkoutやhooks/pre_buildなどでDockerfile生成も試みましたが，Docker Hubは以下のようなことが出来ないことがわかりました．

1. ビルド毎に--build-argを指定できない（つまり，ARGを使って１つのDockerfileを使い回すことができない）
2. Web UIの「Dockerfile location」で指定したファイルがGitリポジトリに存在しないとエラーになる（つまり，ビルド前にファイルを自動生成できない）
3. Web UIの「Dockerfile location」で指定したファイルの内容をビルド前に書き換えても機能しない（つまり，ダミーのDockerfileをGitリポジトリにコミットしておき，ビルド前に書き換えるという方法も動作しない）

Docker Hubの自動ビルドでmulti-archイメージを生成する場合，作成するイメージの数（platform x arch）だけDockerfileファイルを予めGitリポジトリにコミットしておく必要があります．これはメンテナンス性を損ねるため良い方法ではありません．仕方がないので，GitHub Actionsでイメージをビルドするようにしました．

### タグの命名規則

mirakcと同じにしてあります．
https://github.com/masnagam/mirakc/blob/master/docs/docker.md#pre-built-images-in-dockerhub

公式`node`イメージがarm32v6など古いARMはサポートしていないため，除外してあります．