### PR TITLE
theme-colorの追加

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,6 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <meta name="mobile-web-app-capable" content="yes">
+        <meta name="theme-color" content="#3f51b5">
         <link rel="icon" href="<%= BASE_URL %>favicon.png" />
         <link rel="apple-touch-icon-precomposed" href="<%= BASE_URL %>ios.png" sizes="180x180"></link>
         <link rel="icon" href="<%= BASE_URL %>android.png"></link>


### PR DESCRIPTION
Chrome for Androidで端末側のStatusBarの色をアプリのToolbarの色と一致させる

## 概要(Summary)

- Chrome for AndroidでStatus BarとアプリのToolbarの色が一致するように。 
[theme-color on MDN
](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)
Chrome(一部対応)とChrome for Android、Samsung Internetで色がつくようになります。


![image](https://user-images.githubusercontent.com/31959526/96360330-43aa6700-1157-11eb-90e2-adca7cf4e415.png)
![image](https://user-images.githubusercontent.com/31959526/96360339-5755cd80-1157-11eb-91f8-7f1ddb694683.png)
![image](https://user-images.githubusercontent.com/31959526/96360422-317cf880-1158-11eb-8329-dbd5bc85b4b8.jpg)
