### PR TITLE
検索の長さが秒になっている

### DIFF
--- a/client/src/model/state/search/SearchState.ts
+++ b/client/src/model/state/search/SearchState.ts
@@ -455,10 +455,10 @@ export default class SearchState implements ISearchState {
 
         // 長さ
         if (typeof searchOption.durationMin !== 'undefined') {
-            this.searchOption.durationMin = searchOption.durationMin;
+            this.searchOption.durationMin = searchOption.durationMin * 60;
         }
         if (typeof searchOption.durationMax !== 'undefined') {
-            this.searchOption.durationMax = searchOption.durationMax;
+            this.searchOption.durationMax = searchOption.durationMax * 60;
         }
 
         // 期間
@@ -1036,10 +1036,10 @@ export default class SearchState implements ISearchState {
 
         // duration
         if (option.durationMin !== null) {
-            ruleOption.durationMin = option.durationMin;
+            ruleOption.durationMin = option.durationMin * 60;
         }
         if (option.durationMax !== null) {
-            ruleOption.durationMax = option.durationMax;
+            ruleOption.durationMax = option.durationMax * 60;
         }
 
         // periiod


### PR DESCRIPTION
60をかけて修正

## 概要(Summary)

- 検索の長さに60をかけて分に

## スクリーンショット

### 修正前
![image](https://user-images.githubusercontent.com/31959526/96360934-5e330f00-115c-11eb-8b51-fa5673d327d1.png)
![image](https://user-images.githubusercontent.com/31959526/96360943-7e62ce00-115c-11eb-925c-571d6d736368.png)

### 修正後
![image](https://user-images.githubusercontent.com/31959526/96360955-90dd0780-115c-11eb-9fe4-bfea6ba93436.png)
