### PR TITLE
recordingFinishCommandが正しく動作するように

### DIFF
--- a/src/model/operator/externalCommand/ExternalCommandManageModel.ts
+++ b/src/model/operator/externalCommand/ExternalCommandManageModel.ts
@@ -244,12 +244,12 @@ export default class ExternalCommandManageModel implements IExternalCommandManag
             } as any);
 
             child.on('exit', () => {
-                this.log.system.info(`${name} process is fin`);
+                this.log.system.info(`${cmd} process is fin`);
                 resolve();
             });
 
             child.on('error', err => {
-                this.log.system.error(`${name} process is error`);
+                this.log.system.error(`${cmd} process is error`);
                 this.log.system.error(String(err));
                 resolve();
             });

--- a/src/model/operator/externalCommand/ExternalCommandManageModel.ts
+++ b/src/model/operator/externalCommand/ExternalCommandManageModel.ts
@@ -113,11 +113,11 @@ export default class ExternalCommandManageModel implements IExternalCommandManag
      * @param recorded: Recorded
      */
     public addRecordingFinishCmd(recorded: Recorded): void {
-        if (typeof this.config.recordingFailedCommand === 'undefined') {
+        if (typeof this.config.recordingFinishCommand === 'undefined') {
             return;
         }
 
-        this.addRecorded(this.config.recordingFailedCommand, recorded);
+        this.addRecorded(this.config.recordingFinishCommand, recorded);
     }
 
     /**


### PR DESCRIPTION
## 概要

- recordingFinishCommandが動かないのを修正

## 動作環境

* OS : `Ubuntu Server 20.04.1 LTS (GNU/Linux 5.4.0-47-generic x86_64)`
* EPGStation : `v2.0.0-beta.0`
* Mirakurun : `v3.3.1`
* Nodejs : `v14.10.1`
* npm : `v6.14.8`

## 変更点

### `/src/model/operator/externalCommand/ExternalCommandManageModel.ts`

- 録画終了時に失敗時のコマンドが実行されそうになっていたので修正。
- 変数名nameが存在しないのでcmdに変更。

```
[2020-10-19T23:10:24.889] [INFO] system - execute cmd: /bin/bash /home/tomochan/XXX/XXX.sh
[2020-10-19T23:10:25.129] [FATAL] system - uncaughtException: name is not defined
[2020-10-19T23:10:25.130] [FATAL] system - ReferenceError: name is not defined
    at ChildProcess.<anonymous> (dist/model/operator/externalCommand/model/operator/externalCommand/ExternalCommandManageModel.ts:247:41)
    at ChildProcess.emit (events.js:314:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12)
```

## 注意事項 ❗ 

- operator logのファイルが生成されていない可能性がある。-> `node ./dist/index.js`で今回のログは確認した。

`operatorLogConfig.yml`の内容

```
appenders: 
  system: 
    type: file
    maxLogSize: 1048576
    backups: 3
    filename: "%OperatorSystem%"
    pattern: "-yyyy-MM-dd" (省略。。。)
  console: 
    type: console
  stdout: 
    type: stdout
categories: 
  default: 
    appenders: 
      - console
      - stdout
    level: info
  system: 
    appenders: 
      - system
      - stdout
    level: info (省略。。。)
```

### 権限回り

```
tomochan@tomontu-server:~/EPGStationV2$ ls -all ./logs/Operator/
drwxrwxr-x 2 tomochan tomochan 4096 Oct  4 22:00 .
-rw-rw-r-- 1 tomochan tomochan    0 Oct  4 22:00 .gitkeep
tomochan@tomontu-server:~/EPGStationV2$ ls -all ./logs/Service/
drwxrwxr-x 2 tomochan tomochan   4096 Oct 19 08:46 .
-rw-r--r-- 1 epgstation     video    394650 Oct 19 23:28 access.log
-rw-rw-r-- 1 tomochan tomochan      0 Oct  4 22:00 .gitkeep
-rw-r--r-- 1 epgstation     video       591 Oct 18 23:55 stream.log
-rw-r--r-- 1 epgstation     video     30406 Oct 19 23:19 system.log
```