### PR TITLE
録画終了後に予約一覧から古い予約を削除する

### DIFF
--- a/src/model/operator/recording/RecorderModel.ts
+++ b/src/model/operator/recording/RecorderModel.ts
@@ -26,6 +26,7 @@ import IDropCheckerModel from './IDropCheckerModel';
 import IRecorderModel from './IRecorderModel';
 import IRecordingStreamCreator from './IRecordingStreamCreator';
 import IRecordingUtilModel from './IRecordingUtilModel';
+import IReservationManageModel from '../reservation/IReservationManageModel';
 
 /**
  * Recorder
@@ -44,6 +45,7 @@ class RecorderModel implements IRecorderModel {
     private dropChecker: IDropCheckerModel;
     private recordingUtil: IRecordingUtilModel;
     private recordingEvent: IRecordingEvent;
+    private reservationManageModel: IReservationManageModel;
 
     private reserve!: Reserve;
     private recordedId: apid.RecordedId | null = null;
@@ -74,6 +76,7 @@ class RecorderModel implements IRecorderModel {
         @inject('IDropCheckerModel') dropChecker: IDropCheckerModel,
         @inject('IRecordingUtilModel') recordingUtil: IRecordingUtilModel,
         @inject('IRecordingEvent') recordingEvent: IRecordingEvent,
+        @inject('IReservationManageModel') reservationManageModel: IReservationManageModel,
     ) {
         this.log = logger.getLogger();
         this.config = configuration.getConfig();
@@ -87,6 +90,7 @@ class RecorderModel implements IRecorderModel {
         this.dropChecker = dropChecker;
         this.recordingUtil = recordingUtil;
         this.recordingEvent = recordingEvent;
+        this.reservationManageModel = reservationManageModel;
     }
 
     /**
@@ -547,6 +551,14 @@ class RecorderModel implements IRecorderModel {
             // 録画完了の通知
             if (recorded !== null) {
                 this.recordingEvent.emitFinishRecording(this.reserve, recorded, this.isStopRec);
+            }
+
+            // 予約一覧から削除
+            if (
+                recorded === null ||
+                recorded.endAt <= new Date().getTime() + IRecordingStreamCreator.PREP_TIME + 1000
+            ) {
+                this.reservationManageModel.cleanup();
             }
         }
 


### PR DESCRIPTION
## 概要(Summary)

予約一覧に録画完了済みの予約が表示されたままになるので、録画完了後に古い予約が削除されるようにしました

### 環境
* Version of EPGStation: `2.0.0`
* Version of Mirakurun: `3.3.1`
* Version of Node: `14.4.0`
* Version of NPM: `6.14.5`
* OS: Raspbian 10.4
* Architecture: x86, armv7l

---

祝 v2 🎉 