### PR TITLE
Encord実行時の変数にHALF_WIDTH_NAMEを追加する

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -797,6 +797,7 @@ concurrentEncodeNum: 1
 | FFPROBE            | string         | ffprobe パス                                                                  |
 | DIR                | string         | 予約時に設定した directory 文字列                                             |
 | NAME               | string         | 番組名                                                                        |
+| HALF_WIDTH_NAME    | string         | 番組名(半角)                                                                  |
 | DESCRIPTION        | string \| null | 番組概要                                                                      |
 | EXTENDED           | string \| null | 番組詳細                                                                      |
 | VIDEOTYPE          | string \| null | "mpeg2" \| "h.264" \| "h.265"                                                 |

--- a/src/model/service/encode/EncodeManageModel.ts
+++ b/src/model/service/encode/EncodeManageModel.ts
@@ -246,6 +246,7 @@ class EncodeManageModel implements IEncodeManageModel {
                     FFMPEG: config.ffmpeg,
                     FFPROBE: config.ffprobe,
                     NAME: recorded.name,
+                    HALF_WIDTH_NAME: recorded.halfWidthName,
                     DESCRIPTION: recorded.description || '',
                     EXTENDED: recorded.extended || '',
                     VIDEOTYPE: recorded.videoType || '',


### PR DESCRIPTION
## 概要(Summary)
Encord実行時の変数に`HALF_WIDTH_NAME`を追加するものです。
ファイル名の変数では`%HALF_WIDTH_TITLE%`がありますが、
エンコード実行時のタイトル情報は全角でしか渡せない状態になっていたので追加しました。

## 理由
v1の頃は`"convertDBStr": "oneByte"`をつけて運用しており、その際エンコードスクリプトに渡されるNAMEは半角にされたものでした。v2では、`convertDBStr`が廃止され、設定で表示上や、ファイル名は(`%HALF_WIDTH_TITLE%`で)半角にできますが、エンコードスクリプトに半角化した番組名を渡せなくなりました。
エンコードスクリプトは自由度が高いのでスクリプト側で半角にすることも当然できますが、
EPGStationで半角データを持っているのでそのまま渡せるオプションがあれば便利ではないかと。

不要でしたら閉じていただいても全然構いません。
もし修正箇所が違うなどありましたら、ご教示ください。