### PR TITLE
GitHub ActionsのDockerワークフローの修正

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,44 +2,75 @@ name: Docker
 
 on:
   push:
+    branches:
+      - master
     tags:
       - '*'
+
+env:
+  MAIN_DISTRO: debian
 
 jobs:
   build:
     strategy:
       matrix:
-        target:
+        distro:
           - alpine
           - debian
         include:
-          - target: alpine
-            platforms: 'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8'
-            tag-latest: false
-            tag-semver: |
-              v{{version}}-alpine
-            tag-custom: alpine
-            tag-custom-only: false
-          - target: debian
-            platforms: 'linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8'
-            tag-latest: true
-            tag-semver: |
-              v{{version}}-debian
-              v{{version}}
-            tag-custom: debian
-            tag-custom-only: false
+          - distro: alpine
+            platforms: >-
+              linux/386,
+              linux/amd64,
+              linux/arm/v6,
+              linux/arm/v7,
+              linux/arm64/v8,
+          - distro: debian
+            # docker/setup-*-action has not supported linux/arm/v5.
+            platforms: >-
+              linux/386,
+              linux/amd64,
+              linux/arm/v7,
+              linux/arm64/v8,
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Docker metadata
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          images: ${{ secrets.DOCKERHUB_IMAGE }}
-          tag-latest: ${{ matrix.tag-latest }}
-          tag-semver: ${{ matrix.tag-semver }}
-          tag-custom: ${{ matrix.tag-custom }}
-          tag-custom-only: ${{ matrix.tag-custom-only }}
+      - name: Docker tags
+        id: docker-tags
+        run: |
+          IMAGE="${{ secrets.DOCKERHUB_IMAGE }}"
+          if echo "$GITHUB_REF" | grep -e '^refs/heads/' >/dev/null 2>&1; then
+            GIT_BRANCH=$(echo "$GITHUB_REF" | sed -e 's|^refs/heads/||')
+            MAIN_TAG="$IMAGE:$GIT_BRANCH-${{ matrix.distro }}"
+            TAGS="$MAIN_TAG"
+            if [ "$MAIN_DISTRO" = "${{ matrix.distro }}" ]; then
+              TAGS="$TAGS,$IMAGE:$GIT_BRANCH"
+            fi
+          else
+            GIT_TAG=$(echo "$GITHUB_REF" | sed -e 's|^refs/tags/||')
+            MAIN_TAG="$IMAGE:$GIT_TAG-${{ matrix.distro }}"
+            TAGS="$MAIN_TAG"
+            if [ "$MAIN_DISTRO" = "${{ matrix.distro }}" ]; then
+              TAGS="$TAGS,$IMAGE:$GIT_TAG"
+            fi
+            # Always update latest image tags when a new git tag is created.
+            #
+            # You need to change the condition like below if you want to update latest image tags
+            # only when a v2 git tag is created:
+            #
+            #   if npx semver -r '">1"' "$GIT_TAG" >/dev/null 2>&1; then
+            #     # update latest image tags
+            #   fi
+            #
+            TAGS="$TAGS,$IMAGE:${{ matrix.distro }}"
+            if [ "$MAIN_DISTRO" = "${{ matrix.distro }}" ]; then
+              TAGS="$TAGS,$IMAGE:latest"
+            fi
+          fi
+          echo "Main tag: $MAIN_TAG"
+          echo "Tags: $TAGS"
+          echo "::set-output name=main-tag::$MAIN_TAG"
+          echo "::set-output name=tags::$TAGS"
       - name: Setup QEMU user-mode emulation
         uses: docker/setup-qemu-action@v1
       - name: Setup Docker Buildx
@@ -48,9 +79,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.target }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-buildx-${{ matrix.distro }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.target }}-
+            ${{ runner.os }}-buildx-${{ matrix.distro }}-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -60,10 +91,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: Dockerfile.${{ matrix.target }}
+          file: Dockerfile.${{ matrix.distro }}
           platforms: ${{ matrix.platforms }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.docker-tags.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,151 +2,68 @@ name: Docker
 
 on:
   push:
-    branches:
-      - master
     tags:
       - '*'
-  # 現時点では、GitHub ActionsのWeb UIは、過去に実行したジョブの再実行はサポート
-  # しているが、指定したタグに対する実行などはサポートしていない。代替手段とし
-  # て、GitHub APIを使ったビルドの実行を可能とするよう、以下を設定しておく。
-  #
-  # 以下のようなスクリプトで、指定したタグのイメージを作成できる。
-  # ----------------------------------------------------------------------------
-  # REPO='l3tnun/EPGStation'
-  # GITHUB_TOKEN='token...'
-  # VERSION='1.6.8'
-  #
-  # JSON=$(cat <<EOF
-  # {
-  # "event_type": "build-docker-images",
-  # "client_payload": {
-  #    "ref": "$VERSION",  # ビルド対象のブランチ、タグ、またはコミットハッシュ
-  #    "latest": true      # latestタグ系を更新するかどうか
-  #  }
-  # }
-  # EOF
-  # )
-  #
-  # echo "$JSON" | curl https://api.github.com/repos/$REPO/dispatches \
-  #   -X POST -d @- \
-  #   -H "Authorization: token $GITHUB_TOKEN" \
-  #   -H "Content-Type: application/json"
-  # ----------------------------------------------------------------------------
-  repository_dispatch:
-    types:
-      - build-docker-images
-
-env:
-  DOCKER_BUILDKIT: 1
-  DOCKER_CLI_EXPERIMENTAL: enabled
-  MAIN_PLATFORM: debian
 
 jobs:
-  build-images:
-    # Fork先リポジトリーでは実行しない。
-    #
-    # 以下の条件では、`env.*`や`secrets.*`は使えない。
-    # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-    if: github.repository == 'l3tnun/EPGStation'
+  build:
     strategy:
       matrix:
-        platform:
+        target:
           - alpine
           - debian
-        arch:
-          # 公式のnodeイメージはarm32v6以前をサポートしていない
-          - amd64
-          - arm32v7
-          - arm64v8
+        include:
+          - target: alpine
+            platforms: 'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8'
+            tag-latest: false
+            tag-semver: |
+              v{{version}}-alpine
+            tag-custom: alpine
+            tag-custom-only: false
+          - target: debian
+            platforms: 'linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8'
+            tag-latest: true
+            tag-semver: |
+              v{{version}}-debian
+              v{{version}}
+            tag-custom: debian
+            tag-custom-only: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set VERSION
-        run: |-
-          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Checkout a specific src
-        uses: actions/checkout@v2
+      - name: Docker metadata
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          ref: ${{ github.event.client_payload.ref }}
-        if: github.event_name == 'repository_dispatch'
-      - name: Override VERSION
-        run: |-
-          echo "VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
-        if: github.event_name == 'repository_dispatch'
+          images: ${{ secrets.DOCKERHUB_IMAGE }}
+          tag-latest: ${{ matrix.tag-latest }}
+          tag-semver: ${{ matrix.tag-semver }}
+          tag-custom: ${{ matrix.tag-custom }}
+          tag-custom-only: ${{ matrix.tag-custom-only }}
       - name: Setup QEMU user-mode emulation
-        run: |-
-          sudo apt-get update
-          sudo apt-get install -y qemu qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Build image
-        # 現時点では、`--squash`などの実験的機能はGitHub Actionsでは動かない
-        run: |-
-          docker build -t ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }} -f Dockerfile.${{ matrix.platform }} --no-cache --build-arg arch=${{ matrix.arch }} .
-      - name: Login to DockerHub
-        # DOCKERHUB_TOKENが登録されていない場合は、以下は失敗する
-        run: |-
-          docker login -u "${{ secrets.DOCKERHUB_USER }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
-      - name: Push image
-        run: |-
-          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }}
-      - name: Update latest tags for each platform
-        run: |-
-          docker tag ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-${{ matrix.arch }}
-          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-${{ matrix.arch }}
-        if: env.VERSION != 'master'
-      - name: Update the main platform tags
-        run: |-
-          docker tag ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-${{ matrix.arch }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.arch }}
-          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.arch }}
-        if: matrix.platform == env.MAIN_PLATFORM
-      - name: Update latest tags for the main platform
-        run: |-
-          docker tag ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-${{ matrix.arch }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.arch }}
-          docker push ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.arch }}
-        if: env.VERSION != 'master' && matrix.platform == env.MAIN_PLATFORM
-  build-multiarch-image:
-    strategy:
-      matrix:
-        platform:
-          - alpine
-          - debian
-    runs-on: ubuntu-latest
-    needs: build-images
-    steps:
-      - name: Set VERSION
-        run: |-
-          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Override VERSION
-        run: |-
-          echo "VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
-        if: github.event_name == 'repository_dispatch'
-      - name: Login to DockerHub
-        run: |-
-          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create and push the manifest for each platform
-        run: |-
-          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-amd64 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm64v8
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm32v7 --os linux --arch arm --variant v7
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}-arm64v8 --os linux --arch arm64 --variant v8
-          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-${{ matrix.platform }}
-      - name: Update latest tag for each platform
-        run: |-
-          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-amd64  ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm64v8
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm32v7 --os linux --arch arm --variant v7
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }} ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}-arm64v8 --os linux --arch arm64 --variant v8
-          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}:${{ matrix.platform }}
-        if: env.VERSION != 'master'
-      - name: Update the version tag for the main platform
-        run: |-
-          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-amd64 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm64v8
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm32v7 --os linux --arch arm --variant v7
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION ${{ secrets.DOCKERHUB_IMAGE }}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8
-          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}:$VERSION
-        if: matrix.platform == env.MAIN_PLATFORM
-      - name: Update the latest tag for the main platform
-        run: |-
-          docker manifest create ${{ secrets.DOCKERHUB_IMAGE }} ${{ secrets.DOCKERHUB_IMAGE }}:amd64 ${{ secrets.DOCKERHUB_IMAGE }}:arm32v7 ${{ secrets.DOCKERHUB_IMAGE }}:arm64v8
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }} ${{ secrets.DOCKERHUB_IMAGE }}:arm32v7 --os linux --arch arm --variant v7
-          docker manifest annotate ${{ secrets.DOCKERHUB_IMAGE }} ${{ secrets.DOCKERHUB_IMAGE }}:arm64v8 --os linux --arch arm64 --variant v8
-          docker manifest push ${{ secrets.DOCKERHUB_IMAGE }}
-        if: env.VERSION != 'master' && matrix.platform == env.MAIN_PLATFORM
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.target }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.target }}-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.${{ matrix.target }}
+          platforms: ${{ matrix.platforms }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: true

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,20 +1,14 @@
-ARG arch=amd64
-FROM ${arch}/node:14-alpine AS builder
-
-WORKDIR /app
+FROM node:14-alpine AS builder
 RUN apk add --no-cache g++ make pkgconf python
-COPY package*.json .
+WORKDIR /app
 COPY . .
 RUN npm run all-install
 RUN npm run build
 
-
-FROM ${arch}/node:14-alpine
-
-WORKDIR /app
-COPY --from=builder /app .
-
+FROM node:14-alpine
+LABEL maintainer="l3tnun"
+COPY --from=builder /app /app/
 EXPOSE 8888
-
+WORKDIR /app
 ENTRYPOINT ["npm"]
 CMD ["start"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,23 +1,15 @@
-ARG arch=amd64
-
-FROM ${arch}/node:14-buster AS builder
-
+FROM node:14-buster AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update
 RUN apt-get install -y build-essential python
-
-RUN mkdir -p /app
 WORKDIR /app
 COPY . .
 RUN npm run all-install
 RUN npm run build
 
-
-FROM ${arch}/node:14-buster-slim
-
+FROM node:14-buster-slim
+LABEL maintainer="l3tnun"
 COPY --from=builder /app /app/
-
 EXPOSE 8888
 WORKDIR /app
 ENTRYPOINT ["npm"]


### PR DESCRIPTION
## 概要(Summary)

* ~master系イメージの作成の停止~
  * ~短い間隔でタグ付けているので，恐らくなくなっても問題ない~
  * e4f94464e6a89d7c24533d564e7106f91d46168d で復活
* repository_dispatchイベントの使用を停止
  * もう使うことはないと思われるので
* イメージのビルドに`docker buildx`を使うように修正
  * Multi-Archイメージが簡単にビルドできる
* linux/386の追加
  * 簡単に削除できるようになったので追加してみた
* Dockerfile.*に`arch`を指定する必要はなくなったので削除
  * --platformオプションをコマンドラインから指定すればよくなったので

本修正では，v1系のタグを今後付けることはないと仮定しています．そのため，
v1系のタグを付けてしまうと，latest系のタグがv1系のタグで更新されてしま
います．~この仮定が成り立たない場合，Dockerイメージのタグの管理がとても
面倒になります．GitHub Actionsは，条件分岐を伴う複雑な処理を行うには適
していません．素直にv1系のワークフローを別途作成するほうが楽です．ただ
し，GitHub ActionsはYAMLファイルのインクルードをサポートしていないので，
コードクローンが発生します．~ これを回避したい場合，以下のようにワークフ
ローYAMLファイルを生成するなどの方法を採用する必要があります．

https://github.com/mirakc/mirakc/blob/master/scripts/make-github-workflows

e4f94464e6a89d7c24533d564e7106f91d46168d でコメントを付けてありますが，`npx semver`などで判定することでv1系タグにも **対応可能** なように変更しました（ **対応はしていません** ）．