### PR TITLE
manifest.jsonの参照を修正

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <!-- PWA 設定 -->
-        <link rel="manifest" href="<%= BASE_URL %>/manifest.json">
+        <link rel="manifest" href="./manifest.json" crossorigin="use-credentials">
 
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />


### PR DESCRIPTION
## 概要(Summary)

- `manifest.json`を参照するときにsubDirectoryを無視しているのを修正(#370 の修正漏れ )
- `manifest.json`を参照するときに認証情報を渡すように修正

## 詳細
リバースプロキシでの運用では認証等を個人で設定することになるが、
認証等の情報はCookie等に保存されていることが想定される。
`manifest.json`の要求は通常Cookie等に保存された認証情報を使わずに参照されるため、
認証等を設定している環境下では正常に参照できない。
そのため`crossorigin="use-credentials"`を用いて認証情報を渡して`manifest.json`を参照するようにした。
（[参考ページ](https://web.dev/add-manifest/#link-manifest)内、`Add the web app manifest to your pages`部分の`Gotchas!`に記載。）
もし修正が不適切でしたらご教示ください。