### PR TITLE
conf-manualの例を修正

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -702,7 +702,7 @@ uploadTempDir: '/hoge/tmp/upload'
 | EXTENDED    | string \| null | 番組詳細                      |
 
 ```yaml
-reservationAddedCommand: '/bin/node /home/hoge/fuga.js reserve'
+reserveNewAddtionCommand: '/bin/node /home/hoge/fuga.js reserve'
 reserveUpdateCommand: '/bin/node /home/hoge/piyo.js update'
 reservedeletedCommand: '/bin/bash /home/hoge/bar.sh deleted'
 recordingPreStartCommand: '/bin/bash /home/hoge/foo.sh prestart'
@@ -744,9 +744,9 @@ recordingPrepRecFailedCommand: '/usr/bin/logger prepfailed'
 | LOGPATH     | string\| null  | ログファイルのフルパス        |
 
 ```yaml
-recordedStartCommand: '/bin/node /home/hoge/fuga.js start'
-recordedEndCommand: '/bin/bash /home/hoge/foo.sh end'
-recordedFailedCommand: '/usr/bin/logger recfailed'
+recordingStartCommand: '/bin/node /home/hoge/fuga.js start'
+recordingFinishCommand: '/bin/bash /home/hoge/foo.sh end'
+recordingFailedCommand: '/usr/bin/logger recfailed'
 ```
 
 ### encodeProcessNum


### PR DESCRIPTION
## 概要(Summary)

- 外部コマンド実行のマニュアルの例がv1のものになっている箇所を修正

## 詳細
先の #384 をテストするにあたりマニュアルの例をコピーして編集したところ実行されず、戸惑いました。
もし修正が不適切でしたらご教示ください。

## 確認
エンコードを除く外部コマンド実行系の設定は、変更してもEPGStationを再起動しなければ
反映されていないようですが、正常な動作でしょうか。
私の環境ではエンコードについては問題なく適応されていますが、それ以外の外部コマンド実行系は
再起動しなければ変更した内容が適応されていないように見られます。
適応条件等あるのでしょうか？ご教示ください。
