### PR TITLE
エンコードスクリプトが、デュアルモノをエンコード出来なかったので修正した

### DIFF
--- a/config/enc3.js
+++ b/config/enc3.js
@@ -40,13 +40,13 @@ if (isDualMono) {
     Array.prototype.push.apply(args, [
         '-filter_complex',
         'channelsplit[FL][FR]',
-        '-map 0:v',
-        '-map [FL]',
-        '-map [FR]',
-        '-metadata:s:a:0 language=jpn',
-        '-metadata:s:a:1 language=eng',
+        '-map', '0:v',
+        '-map', '[FL]',
+        '-map', '[FR]',
+        '-metadata:s:a:0', 'language=jpn',
+        '-metadata:s:a:1', 'language=eng',
     ]);
-    Array.prototype.push.apply(args, ['-c:a ac3', '-ar 48000', '-ab 256k']);
+    Array.prototype.push.apply(args, ['-c:a', 'ac3', '-ar', '48000', '-ab', '256k']);
 } else {
     // audio dataをコピー
     Array.prototype.push.apply(args, ['-c:a', 'aac']);


### PR DESCRIPTION
## 概要(Summary)

- enc3.jsを利用してエンコードをしようとした所、エンコードに失敗する。

## 詳細

- デュアルモノ放送をエンコードした際、エンコードがスタートせずmp4ファイルも作成されずに終了する。

## 確認

- ニュース[二][字] NHK総合1 01/17 18:00 ~ 18:05(5分) [1/0 + 1/0モード(デュアルモノ)]を、enc3.jsでエンコードして動作を確認。
  enc3.jsを修正した所、無事にmp4ファイルが作成されました。

