### PR TITLE
streamfilesのpathが絶対パスになっていた

### DIFF
--- a/client/src/components/video/LiveHLSVideo.vue
+++ b/client/src/components/video/LiveHLSVideo.vue
@@ -75,7 +75,7 @@ export default class LiveHLSVideo extends BaseVideo {
             throw new Error('StreamIdIsNull');
         }
 
-        const videoSrc = `/streamfiles/stream${streamId}.m3u8`;
+        const videoSrc = `./streamfiles/stream${streamId}.m3u8`;
         if (Hls.isSupported() === false || (UaUtil.isiOS() === true && UaUtil.isiPadOS() === false)) {
             // hls.js 非対応
             this.setSrc(videoSrc);

--- a/client/src/components/video/RecordedHLSStreamingVideo.vue
+++ b/client/src/components/video/RecordedHLSStreamingVideo.vue
@@ -161,7 +161,7 @@ export default class RecordedHLSStreamingVideo extends BaseVideo {
             throw new Error('StreamIdIsNull');
         }
 
-        const videoSrc = `/streamfiles/stream${streamId}.m3u8`;
+        const videoSrc = `./streamfiles/stream${streamId}.m3u8`;
         if (this.isSupportedHLSjs() === true) {
             // hls.js 非対応
             this.setSrc(videoSrc);

--- a/doc/linux-nginx.md
+++ b/doc/linux-nginx.md
@@ -27,21 +27,22 @@ port と同じポート番号を設定しても良い
 | number | port と同じ  | no   |
 
 ```yaml
-socketioPort: 8889
+socketioPort: 8888
 ```
 
 ### clientSocketioPort
 
-### EPGStation の Web クライアントが接続する Socket.IO のポート番号
+#### EPGStation の Web クライアントが接続する Socket.IO のポート番号
 
-リバースプロキシを使用している場合は必須となる
+リバースプロキシを使用している場合は必須となる。
+リバースプロキシの待受ポートと同じポート番号を設定する事。
 
 | 種類   | デフォルト値        | 必須 |
 | ------ | ------------------- | ---- |
 | number | socketioPort と同じ | no   |
 
 ```yaml
-clientSocketioPort: 8889
+clientSocketioPort: 80
 ```
 
 ## nginx 設定


### PR DESCRIPTION
## 概要(Summary)
streamfilesのpathが絶対パスになっていた為、リバースプロキシを通すと正常にストリーミングできなかった。

- Fixed #xx
相対パスに修正しました。
合わせてリバースプロキシを利用するためのドキュメントを更新しました。