### PR TITLE
検索結果表示上限を600に

### DIFF
--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -359,7 +359,7 @@ export default class Settings extends Vue {
             this.rulesLengthItems.push(item);
         }
 
-        for (let i = 50; i <= 300; i += 50) {
+        for (let i = 50; i <= 600; i += 50) {
             const item: SelectItem = {
                 text: i.toString(10),
                 value: i,


### PR DESCRIPTION
## 概要(Summary)
検索結果表示上限を600へ増やしました。デフォルトは300のままです。
