### PR TITLE
GitHub ActionsのDockerワークフローのビルド時間を短縮

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,13 +1,24 @@
-FROM node:14-alpine AS builder
+# 詳細については、Dockerfile.debianのコメントを参照。
+FROM --platform=$BUILDPLATFORM node:14-buster AS client-builder
+COPY client/package*.json /app/client/
+WORKDIR /app/client
+RUN npm install --loglevel=info
+COPY . /app/
+RUN npm run build --loglevel=info
+
+FROM node:14-alpine AS server-builder
 RUN apk add --no-cache g++ make pkgconf python
 WORKDIR /app
+COPY package*.json /app/
+RUN npm install --loglevel=info
 COPY . .
-RUN npm run all-install
-RUN npm run build
+RUN rm -rf client
+RUN npm run build-server --loglevel=info
 
 FROM node:14-alpine
 LABEL maintainer="l3tnun"
-COPY --from=builder /app /app/
+COPY --from=server-builder /app /app/
+COPY --from=client-builder /app/client /app/client/
 EXPOSE 8888
 WORKDIR /app
 ENTRYPOINT ["npm"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,15 +1,40 @@
-FROM node:14-buster AS builder
+# クライアントはプラットフォーム依存のコードを含まないため、BUILDPLATFORMでビルドした結果を
+# 全てのTARGETPLATFORMで再利用できる。これによりビルド時間を短縮できる。
+FROM --platform=$BUILDPLATFORM node:14-buster AS client-builder
+COPY client/package*.json /app/client/
+WORKDIR /app/client
+# どこで時間が掛かっているのか確認できるようにログレベルを変更。
+RUN npm install --loglevel=info
+# clientフォルダー外にビルドに必要なファイルが存在するため、全てコピーする。
+COPY . /app/
+RUN npm run build --loglevel=info
+
+# サーバーはsqlite3のようなプラットフォーム依存のネイティブ・アドオンを含んでいる。そのため、各
+# TARGETPLATFORMごとにソースをビルドしなければならない。BUILDPLATFORM以外のTARGETPLATFORMでは、QEMU
+# 上でnpmコマンドを実行することになるため、どうしても時間が掛かる。
+#
+# `npm install`時にネイティブ・アドオンをクロスビルドできればビルド時間を短縮できるが、現時点では明
+# 確な手順は存在しない。https://github.com/mapbox/node-pre-gyp/issues/348を見れはそれが分かる。
+#
+# `npm run build-server`はプラットフォーム依存処理を含まないため、これをBUILDPLATFORMで実行すること
+# でビルド時間をさらに短縮可能だが、手順が煩雑で面倒なので現時点では行っていない。
+FROM node:14-buster AS server-builder
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y build-essential python
 WORKDIR /app
+COPY package*.json /app/
+RUN npm install --loglevel=info
+# 最終イメージのサイズ削減のため、すべてコピーした後でclientフォルダーを削除。clientフォルダー以外
+# をコピーする方法は，ファイルが追加された場合に変更する必要があるため採用しない。
 COPY . .
-RUN npm run all-install
-RUN npm run build
+RUN rm -rf client
+RUN npm run build-server --loglevel=info
 
 FROM node:14-buster-slim
 LABEL maintainer="l3tnun"
-COPY --from=builder /app /app/
+COPY --from=server-builder /app /app/
+COPY --from=client-builder /app/client /app/client/
 EXPOSE 8888
 WORKDIR /app
 ENTRYPOINT ["npm"]


### PR DESCRIPTION
## 概要(Summary)

ビルド時間を短縮するため，クライアントのビルドを分離した．
詳細はDockerfile.debianのコメントを参照．

20-30分程度ビルド時間が短縮されると思われる．
