### PR TITLE
diskusage-ngを1.0.1に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2413,9 +2413,9 @@
             }
         },
         "diskusage-ng": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/diskusage-ng/-/diskusage-ng-1.0.0.tgz",
-            "integrity": "sha512-XQq/mF23Oi8PmQ0rNnOFhyOz3yH3Fz8Dxhz2+p7Z5JEaS51s2OkvHLI9rqdidtbhA15WGvV6wzG/DXadPuQzyw=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/diskusage-ng/-/diskusage-ng-1.0.1.tgz",
+            "integrity": "sha512-lqxIa+YO8X3VN0+ADbMIY3h5qnogO2d/Tr8q4VXszg7TFSwaEiPQFjeW5C0s6PrwdiQatR29N9CDB7+WdqPl0g=="
         },
         "doctrine": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "aribts": "2.1.12",
         "axios": "0.21.1",
         "body-parser": "1.19.0",
-        "diskusage-ng": "1.0.0",
+        "diskusage-ng": "1.0.1",
         "express": "4.17.1",
         "express-openapi": "7.0.2",
         "file-type": "15.0.1",


### PR DESCRIPTION
## 概要(Summary)

- 依存パッケージ`diskusage-ng`のバージョンを`1.0.1`に更新

## 経緯

録画ファイル保存先のディレクトリパスが非常に長い際に、空き容量がうまく取得できない問題がありました。
調査の結果、`diskusage-ng`が行う容量情報のパースが当該条件の際に失敗することが原因だと分かりました。
そのため、`diskusage-ng`のコードに修正を加えました。
よって、その修正をEPGStationに反映するために`diskusage-ng`のバージョンを更新する必要がありました。

## 変更点

- `diskusage-ng`のバージョンを修正後のバージョンである`1.0.1`に更新しました。