### PR TITLE
ルール編集で長さの最小と最大が3600倍される不具合を修正

### DIFF
--- a/client/src/model/state/search/SearchState.ts
+++ b/client/src/model/state/search/SearchState.ts
@@ -455,10 +455,10 @@ export default class SearchState implements ISearchState {
 
         // 長さ
         if (typeof searchOption.durationMin !== 'undefined') {
-            this.searchOption.durationMin = searchOption.durationMin * 60;
+            this.searchOption.durationMin = Math.floor(searchOption.durationMin / 60);
         }
         if (typeof searchOption.durationMax !== 'undefined') {
-            this.searchOption.durationMax = searchOption.durationMax * 60;
+            this.searchOption.durationMax = Math.floor(searchOption.durationMax / 60);
         }
 
         // 期間


### PR DESCRIPTION
## 概要(Summary)

すでに最小もしくは最大の長さが格納されているルールを再編集する際、編集欄に3600倍の値で呼び出されてしまう不具合を修正しました。
ソース全体を読んだわけではないので修正に副作用があるかもしれません。
修正に不備があれば、ご指摘いただければ幸いです。