### PR TITLE
Pass all environments to the encode process

### DIFF
--- a/src/model/service/encode/EncodeManageModel.ts
+++ b/src/model/service/encode/EncodeManageModel.ts
@@ -260,7 +260,7 @@ class EncodeManageModel implements IEncodeManageModel {
             priority: EncodeManageModel.ENCODE_PRIPORITY,
             spawnOption: {
                 env: {
-                    PATH: process.env['PATH'],
+                    ...process.env,
                     RECORDEDID: recorded.id.toString(10),
                     INPUT: inputFilePath,
                     OUTPUT: outputFilePath === null ? '' : outputFilePath,


### PR DESCRIPTION
## 概要(Summary)

ffmpegの実行に環境変数 `LD_LIBRARY_PATH` が必要な環境でエンコード時にffmpegがエラーを吐く問題の修正です。
`LD_LIBRARY_PATH` だけを渡しても良いとは思いましたが、他の環境で別の環境変数絡みの問題が起きる可能性もありますし、逆にすべての環境変数を渡すことで不都合が生じるわけでもないと思うので、すべての環境変数を渡すように変更しました。

自分の環境でしか確認していませんので、もしほかの環境で悪影響を及ぼすようでしたらrejectしてください。