### PR TITLE
ProcessUtil.parseCmdStr で %ROOT% を置換。

### DIFF
--- a/src/model/service/encode/EncodeProcessManageModel.ts
+++ b/src/model/service/encode/EncodeProcessManageModel.ts
@@ -33,12 +33,6 @@ class EncodeProcessManageModel implements IEncodeProcessManageModel {
      * @return Promise<ChildProcess>
      */
     public create(option: CreateProcessOption): Promise<ChildProcess> {
-        // replace %ROOT%
-        option.cmd =
-            process.platform === 'win32'
-                ? option.cmd.replace('%ROOT%', EncodeProcessManageModel.ROOT_PATH.replace(/\\/g, '\\\\'))
-                : option.cmd.replace('%ROOT%', EncodeProcessManageModel.ROOT_PATH);
-
         return new Promise<ChildProcess>(async (resolve, reject) => {
             if (this.childs.length >= this.maxEncode) {
                 // プロセス数が上限に達しているとき
@@ -259,7 +253,6 @@ class EncodeProcessManageModel implements IEncodeProcessManageModel {
 }
 
 namespace EncodeProcessManageModel {
-    export const ROOT_PATH = path.join(__dirname, '..', '..', '..', '..');
     export const KILL_CHILD_EVENT = 'killChild';
 }
 

--- a/src/util/ProcessUtil.ts
+++ b/src/util/ProcessUtil.ts
@@ -1,5 +1,6 @@
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 
 namespace ProcessUtil {
     /**
@@ -39,6 +40,8 @@ namespace ProcessUtil {
         args: string[];
     }
 
+    export const ROOT_PATH = path.join(__dirname, '..', '..').replace(new RegExp(`\\${path.sep}$`), '');
+
     /**
      * 渡された cmd 文字列を bin と args に分離する
      * @param cmd: string
@@ -61,10 +64,15 @@ namespace ProcessUtil {
             throw new Error('CmdBinIsNotFound');
         }
 
-        // 引数内の %SPACE% を半角スペースに置換
-        args = args.map(arg => {
-            return arg.replace(/%SPACE%/g, ' ');
-        });
+        args = args
+            .map(arg => {
+                // 引数内の %ROOT% を置換
+                return arg.replace(/%ROOT%/g, ROOT_PATH);
+            })
+            .map(arg => {
+                // 引数内の %SPACE% を半角スペースに置換
+                return arg.replace(/%SPACE%/g, ' ');
+            });
 
         return {
             bin: bin,


### PR DESCRIPTION
## 概要(Summary)

- ProcessUtil.parseCmdStr で引数内の `%ROOT%` を置換するように変更。

外部コマンド実行でも `%ROOT%` が使えるようになります。