### PR TITLE
マニュアルのtypo修正

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -172,7 +172,7 @@ mysql:
     port: 3306
     user: username
     password: password
-    database": databaseName
+    database: databaseName
 ```
 
 ### sqlite


### PR DESCRIPTION
## 概要(Summary)

細かなとこですが、マニュアル内の`MySQL の接続設定（MySQL 使用時は必須）`の章にてmysqlの設定例に不要なタブルクオーテーションがあったので削除しました。

