### PR TITLE
NHK-ETVを全録できない（SQLite）

### DIFF
--- a/src/model/db/ReserveDB.ts
+++ b/src/model/db/ReserveDB.ts
@@ -284,6 +284,19 @@ export default class ReserveDB implements IReserveDB {
             return option.times.indexOf(time) === i;
         });
 
+        // option.times の連続した時間を一つにまとめる
+        option.times = option.times.reduce((acc, cur, index) => {
+            if (index == 0) {
+                return acc;
+            }
+            if (acc[acc.length - 1].endAt == cur.startAt) {
+                acc[acc.length - 1].endAt = cur.endAt;
+            } else {
+                acc.push(cur);
+            }
+            return acc;
+        }, option.times.slice(0, 1));
+
         // times
         let timesQuery = '';
         const timesValues: any = {};


### PR DESCRIPTION
## 概要(Summary)

UI 上でNHK-ETVを全録しようと、「検索」＞「（ルール）追加」した所、ルールの追加には成功したものの、予約数０件となり全く何も録画されませんでした。（検索時には３００件ほど表示されていた）
ゴソゴソとlogなど見回って見た所、SQLiteのエラーがあるのを見つけました。

```
[2021-04-08T16:15:33.070] [INFO] system - update rule reservation: 1
[2021-04-08T16:16:30.190] [ERROR] system - reserve get error
[2021-04-08T16:16:30.191] [ERROR] system - { QueryFailedError: SQLITE_ERROR: too many SQL variables
    at new QueryFailedError (/home/pi/EPGStation/src/error/QueryFailedError.ts:9:9)
    at handler (/home/pi/EPGStation/src/driver/sqlite/SqliteQueryRunner.ts:79:26)
    at replacement (/home/pi/EPGStation/node_modules/sqlite3/lib/trace.js:25:27)
    at Statement.errBack (/home/pi/EPGStation/node_modules/sqlite3/lib/sqlite3.js:14:21)
  message: 'SQLITE_ERROR: too many SQL variables',
  errno: 1,
  code: 'SQLITE_ERROR',
  __augmented: true,
  name: 'QueryFailedError',
  query:
   'SELECT "reserve"."id" AS "reserve_id", "reserve"."updateTime" AS "reserve_updateTime", "reserve"."ruleId" AS "reserve_ruleId", "reserve"."ruleUpdateCnt" AS "reserve_ruleUpdateCnt", "reserve"."isSkip" AS "reserve_isSkip", "reserve"."isConflict" AS "reserve_isConflict", "reserve"."allowEndLack" AS "reserve_allowEndLack", "reserve"."tags" AS "reserve_tags", "reserve"."isOverlap" AS "reserve_isOverlap", "reserve"."isIgnoreOverlap" AS "reserve_isIgnoreOverlap", "reserve"."isTimeSpecified" AS "reserve_isTimeSpecified", "reserve"."parentDirectoryName" AS "reserve_parentDirectoryName", "reserve"."directory" AS "reserve_directory", "reserve"."recordedFormat" AS "reserve_recordedFormat", "reserve"."encodeMode1" AS "reserve_encodeMode1", "reserve"."encodeParentDirectoryName1" AS "reserve_encodeParentDirectoryName1", "reserve"."encodeDirectory1" AS "reserve_encodeDirectory1", "reserve"."encodeMode2" AS "reserve_encodeMode2", "reserve"."encodeParentDirectoryName2" AS "reserve_encodeParentDirectoryName2", "reserve"."encodeDirectory2" AS "reserve_encodeDirectory2", "reserve"."encodeMode3" AS "reserve_encodeMode3", "reserve"."encodeParentDirectoryName3" AS "reserve_encodeParentDirectoryName3", "reserve"."encodeDirectory3" AS "reserve_encodeDirectory3", "reserve"."isDeleteOriginalAfterEncode" AS "reserve_isDeleteOriginalAfterEncode", "reserve"."programId" AS "reserve_programId", "reserve"."programUpdateTime" AS "reserve_programUpdateTime", "reserve"."channelId" AS "reserve_channelId", "reserve"."channel" AS "reserve_channel", "reserve"."channelType" AS "reserve_channelType", "reserve"."startAt" AS "reserve_startAt", "reserve"."endAt" AS "reserve_endAt", "reserve"."name" AS "reserve_name", "reserve"."halfWidthName" AS "reserve_halfWidthName", "reserve"."shortName" AS "reserve_shortName", "reserve"."description" AS "reserve_description", "reserve"."halfWidthDescription" AS "reserve_halfWidthDescription", "reserve"."extended" AS "reserve_extended", "reserve"."halfWidthExtended" AS "reserve_halfWidthExtended", "reserve"."genre1" AS "reserve_genre1", "reserve"."subGenre1" AS "reserve_subGenre1", "reserve"."genre2" AS "reserve_genre2", "reserve"."subGenre2"  AS "reserve_subGenre2", "reserve"."genre3" AS "reserve_genre3", "reserve"."subGenre3" AS "reserve_subGenre3", "reserve"."videoT
ype" AS "reserve_videoType", "reserve"."videoResolution" AS "reserve_videoResolution", "reserve"."videoStreamContent" AS "reserve_videoStreamContent", "reserve"."videoComponentType" AS "reserve_videoComponentType", "reserve"."audioSamplingRate" AS "reserve
_audioSamplingRate", "reserve"."audioComponentType" AS "reserve_audioComponentType" FROM "reserve" "reserve" WHERE (("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and
"reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("re
serve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve
"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."
endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and"reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."start
At" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or ("reserve"."endAt" >= ? and "reserve"."startAt" < ?) or
 ...（長いので割愛・同じWHERE文が続く）
```
500件以上の予約をしようとした様で、SQLiteが `too many SQL variables`のエラーで全てのパラメータを受け取れ切れなかった様です。
SQLiteの仕様を調べてみると、、、
https://www.sqlite.org/limits.html
```
the maximum value of a host parameter number is SQLITE_MAX_VARIABLE_NUMBER, which defaults to 999 for SQLite versions prior to 3.32.0 (2020-05-22) or 32766 for SQLite versions after 3.32.0.
```
と言う事で、自分の所のversionは3.27.2で最大999個までだそうです。なので、５００件以上の予約をしようとしてエラーになっていた模様です。

コードを見た所、検索パラメータの時間は連続したものが続きそうだったので、それをまとめる様に書き換えて見ました。これで全ての状況で上手く行くのか良くわかっておりませんが、とりあえず自分の所ではNHK-ETVが全録できる様になりました。