### PR TITLE
ダイアログが表示されている時に番組表がスクロールされないようにする

### DIFF
--- a/client/src/components/guide/GuideScroller.vue
+++ b/client/src/components/guide/GuideScroller.vue
@@ -28,15 +28,15 @@ export default class GuideScroller extends Vue {
     }).bind(this);
 
     public mounted(): void {
-        document.addEventListener('mousedown', this.mousedownListener, false);
-        document.addEventListener('mouseup', this.mouseupListener, false);
-        document.addEventListener('mousemove', this.mousemoveListener, false);
+        (this.$el as HTMLElement).addEventListener('mousedown', this.mousedownListener, false);
+        (this.$el as HTMLElement).addEventListener('mouseup', this.mouseupListener, false);
+        (this.$el as HTMLElement).addEventListener('mousemove', this.mousemoveListener, false);
     }
 
     public beforeDestroy(): void {
-        document.removeEventListener('mousedown', this.mousedownListener, false);
-        document.removeEventListener('mouseup', this.mouseupListener, false);
-        document.removeEventListener('mousemove', this.mousemoveListener, false);
+        (this.$el as HTMLElement).removeEventListener('mousedown', this.mousedownListener, false);
+        (this.$el as HTMLElement).removeEventListener('mouseup', this.mouseupListener, false);
+        (this.$el as HTMLElement).removeEventListener('mousemove', this.mousemoveListener, false);
     }
 
     public onScroll(e: Event): void {


### PR DESCRIPTION
## 概要(Summary)

番組表のダイアログや左メニュー上で文字列選択などのマウス操作をすると、下記動画のように下の番組表がスクロールされてしまいます。
この挙動に違和感があったため、ダイアログ上でマウス操作をしても、下の番組表はスクロールされないようにしました。
実装としては、`mousedown`, `mouseup`, `mousemove` イベントが window.document に張られているのを、`GuideScroller` コンポーネント自体にイベントを張る形に変更しました。

**Before**

https://user-images.githubusercontent.com/14837380/117576849-551e8500-b122-11eb-8260-37c297b47983.mp4

**After**

https://user-images.githubusercontent.com/14837380/117577258-0c67cb80-b124-11eb-8059-1e447d3e0c51.mp4