### PR TITLE
aribb24.js 字幕で可能な限り丸ゴシックを使用するようにする

### DIFF
--- a/client/src/util/HLSUtil.ts
+++ b/client/src/util/HLSUtil.ts
@@ -20,8 +20,8 @@ namespace HLSUtil {
         const config = storageModel.getSavedValue();
 
         const baseOption: any = {
-            normalFont: '"Windows TV MaruGothic", "MS Gothic", "Yu Gothic", sans-serif',
-            gaijiFont: '"Windows TV MaruGothic", "MS Gothic", "Yu Gothic", sans-serif',
+            normalFont: '"Windows TV MaruGothic", "Hiragino Maru Gothic Pro", "HGMaruGothicMPRO", "Yu Gothic Medium", sans-serif',
+            gaijiFont: '"Windows TV MaruGothic", "Hiragino Maru Gothic Pro", "HGMaruGothicMPRO", "Yu Gothic Medium", sans-serif',
             drcsReplacement: true,
             enableAutoInBandMetadataTextTrackDetection: HLSUtil.isSupportedHLSjs() === false,
         };


### PR DESCRIPTION
## 概要(Summary)

字幕のフォントは丸ゴシックが望ましいと思われていますので、font-family を微調整します

すると、macOS の場合は：

- **ヒラギノ丸ゴシック** が使用される

Windows の場合：

- Windows TV 丸ゴシック
- HG丸ゴシックM-PRO　（Office インストール済みの場合に存在する）
- 游ゴシック Medium

の順で適用される。

iOS/Android/Linux はディフォルトで丸ゴシックが入れていないので、sans-serif が適用されます。

## macOS の効果

**ヒラギノ丸ゴシック** が使用されています。

![image](https://user-images.githubusercontent.com/4645762/118584173-5b22fe80-b7d1-11eb-811d-941862e7bfe8.png)

![image](https://user-images.githubusercontent.com/4645762/118583955-dafc9900-b7d0-11eb-9207-c86687e20aaf.png)

![image](https://user-images.githubusercontent.com/4645762/118584265-91607e00-b7d1-11eb-92e6-6b75521a156e.png)

