### PR TITLE
RecordedSearchOptionsのAPI定義が実装と異なっているのを修正

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -1267,9 +1267,13 @@ components:
                 - genres
             properties:
                 channels:
-                    $ref: '#/components/schemas/RecordedChannelListItem'
+                    type: array
+                    items:
+                       $ref: '#/components/schemas/RecordedChannelListItem'
                 genres:
-                    $ref: '#/components/schemas/RecordedGenreListItem'
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/RecordedGenreListItem'
 
         SendVideoLinkToKodiOption:
             description: kodiへビデオリンクを送信するときのオプション


### PR DESCRIPTION
## 概要(Summary)

- https://github.com/l3tnun/EPGStation/commit/3050bbaaeea4ba3a76ba525ab78f2b105384c1c1 で導入された録画済みの検索オプション(RecordedSearchOptions)を返すAPIですが、 api.yml に書かれたレスポンスオブジェクトのプロパティ定義  と 実装が対応していないのを見つけました
  - 定義 https://github.com/l3tnun/EPGStation/commit/3050bbaaeea4ba3a76ba525ab78f2b105384c1c1#diff-e4b643c9704a69d3ab2b8b187024b12decb4fc750ba680383a259770d135f736R1090-R1093  
  - 実装 https://github.com/l3tnun/EPGStation/commit/3050bbaaeea4ba3a76ba525ab78f2b105384c1c1#diff-5dc4d57f63ee782ed3e8240721ffbecd88277f5ab786a12ab8b4a62b7d8ab384R72-R82
- 実装のほうを見るとわかるとおり、 channels と genres プロパティは、実際は、 object ではなく array として表現されています
  - /api/debug で GET ​/recorded​/options を試し、 実際に array として返ってくるのを確認しました
- 既存のほかの部分も これらのプロパティが array であることを想定して実装されていて、問題なく動いているように見えます
  - よって、API定義のほうを現行の実装に合わせて修正しました

これに気づいた理由ですが、自分のほうで /api/docs のOpenAPI定義の出力をもとに、 別言語のEPGStationクライアントのコードを生成して使っているのですが、このクライアントで GET ​/recorded​/options のレスポンスをうまく取得できなかったので気づきました。つまり困るシチュエーションとしてはそれぐらいな気がします。