### PR TITLE
RecordedGenreListItemのAPIスキーマでgenreプロパティを正しく定義する

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -1256,7 +1256,7 @@ components:
                 cnt:
                     description: 録画数
                     type: integer
-                channelId:
+                genre:
                     $ref: '#/components/schemas/ProgramGenreLv1'
 
         RecordedSearchOptions:


### PR DESCRIPTION
## 概要(Summary)

- RecordedGenreListItem という、録画した番組のジャンルごとの数を持っているオブジェクトがありますが、ジャンルのIDのプロパティは実装上は genre のところ api.yml のスキーマでは誤って channelId となっていました
  - 似た役割ですぐ上に記述されている RecordedChannelListItem は channelId で正しいので、これにつられて誤って定義してしまったようです
  - 正しくはgenreなのでAPI定義のほうを修正しました
- https://github.com/l3tnun/EPGStation/pull/497 と同様に、OpenAPI定義から生成したAPIクライアントで、`GET /recorded/options` のレスポンスオブジェクトを参照できなくて気づきました
  - 私が https://github.com/l3tnun/EPGStation/pull/497 の時点で気づいて一緒に直せればよかったですね。すみません
- EPGStation の実装のほうは 正しく genre プロパティを参照できているようで、とくにEPGStation自体のアプリケーションの動作には影響はありません
  -  /api/docs の定義を使って外部アプリケーション用のAPIクライアントを生成し、それを使おうとしたときに影響が出ます