### PR TITLE
マニュアル内リンク修正

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -30,7 +30,7 @@
     -   [ドロップログの保存先を変更したい](#dropLog)
     -   [アクセス URL の設定をルートではなくサブディレクトリ下に変更したい](#subdirectory)
     -   [Swagger UI で使用するサーバリストを変更したい](#apiservers)
-    -   [CORS ヘッダーをすべて許可したい](isallowallcors)
+    -   [CORS ヘッダーをすべて許可したい](#isallowallcors)
 -   [ファイル保存先](#ファイル保存先)
     -   [録画ファイルの保存先を変更したい](#recorded)
     -   [一時録画先を設定したい](#recordedtmp)


### PR DESCRIPTION
## 概要(Summary)

`CORS ヘッダーをすべて許可したい`のマニュアル内リンクが機能していないので修正しました。