### PR TITLE
encodingFinishCommandで渡される環境変数名を修正

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -786,7 +786,7 @@ recordingFailedCommand: '/usr/bin/logger recfailed'
 | RECORDEDID  | number         | recorded id                            |
 | VIDEOFILEID | number \| null | video file id                          |
 | OUTPUTPATH  | string \| null | エンコードしたビデオファイルのフルパス |
-| NODE        | string         | エンコードモード名                     |
+| MODE        | string         | エンコードモード名                     |
 
 ```yaml
 encodingFinishCommand: '/bin/node /home/hoge/fuga.js finish'


### PR DESCRIPTION
## 概要(Summary)

`encodingFinishCommand`で渡される環境変数名が`NODE`になっていたのを`MODE`に修正しました．