### PR TITLE
encodingFinishCommandにいくつかの環境変数を追加する。

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -781,21 +781,21 @@ recordingFailedCommand: '/usr/bin/logger recfailed'
 
 -   実行時に渡される環境変数は以下の通り
 
-| 変数名      | 種類           | 説明                                   |
-| ----------- | -------------- | -------------------------------------- |
-| RECORDEDID  | number         | recorded id                            |
-| VIDEOFILEID | number \| null | video file id                          |
-| OUTPUTPATH  | string \| null | エンコードしたビデオファイルのフルパス |
-| MODE        | string         | エンコードモード名                     |
-| CHANNELID              | number         | channel id                    |
-| CHANNELNAME            | string \| null | 放送局名                      |
-| HALF_WIDTH_CHANNELNAME | string \| null | 放送局名(半角)                |
-| NAME                   | string         | 番組名                        |
-| HALF_WIDTH_NAME        | string         | 番組名(半角)                  |
-| DESCRIPTION            | string \| null | 番組概要                      |
-| HALF_WIDTH_DESCRIPTION | string \| null | 番組概要(半角)                |
-| EXTENDED               | string \| null | 番組詳細                      |
-| HALF_WIDTH_EXTENDED    | string \| null | 番組詳細(半角)                |
+| 変数名                 | 種類           | 説明                                   |
+| ---------------------- | -------------- | -------------------------------------- |
+| RECORDEDID             | number         | recorded id                            |
+| VIDEOFILEID            | number \| null | video file id                          |
+| OUTPUTPATH             | string \| null | エンコードしたビデオファイルのフルパス |
+| MODE                   | string         | エンコードモード名                     |
+| CHANNELID              | number         | channel id                             |
+| CHANNELNAME            | string \| null | 放送局名                               |
+| HALF_WIDTH_CHANNELNAME | string \| null | 放送局名(半角)                         |
+| NAME                   | string         | 番組名                                 |
+| HALF_WIDTH_NAME        | string         | 番組名(半角)                           |
+| DESCRIPTION            | string \| null | 番組概要                               |
+| HALF_WIDTH_DESCRIPTION | string \| null | 番組概要(半角)                         |
+| EXTENDED               | string \| null | 番組詳細                               |
+| HALF_WIDTH_EXTENDED    | string \| null | 番組詳細(半角)                         |
 
 ```yaml
 encodingFinishCommand: '/bin/node /home/hoge/fuga.js finish'

--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -787,6 +787,15 @@ recordingFailedCommand: '/usr/bin/logger recfailed'
 | VIDEOFILEID | number \| null | video file id                          |
 | OUTPUTPATH  | string \| null | エンコードしたビデオファイルのフルパス |
 | MODE        | string         | エンコードモード名                     |
+| CHANNELID              | number         | channel id                    |
+| CHANNELNAME            | string \| null | 放送局名                      |
+| HALF_WIDTH_CHANNELNAME | string \| null | 放送局名(半角)                |
+| NAME                   | string         | 番組名                        |
+| HALF_WIDTH_NAME        | string         | 番組名(半角)                  |
+| DESCRIPTION            | string \| null | 番組概要                      |
+| HALF_WIDTH_DESCRIPTION | string \| null | 番組概要(半角)                |
+| EXTENDED               | string \| null | 番組詳細                      |
+| HALF_WIDTH_EXTENDED    | string \| null | 番組詳細(半角)                |
 
 ```yaml
 encodingFinishCommand: '/bin/node /home/hoge/fuga.js finish'


### PR DESCRIPTION
## 概要(Summary)
v2.5.0で追加された`encodingFinishCommand`に以下の環境変数を追加します。
- CHANNELID
- CHANNELNAME
- HALF_WIDTH_CHANNELNAME
- NAME
- HALF_WIDTH_NAME
- DESCRIPTION
- HALF_WIDTH_DESCRIPTION
- EXTENDED
- HALF_WIDTH_EXTENDED

## 詳細
<details>
<summary>encodingFinishCommand実行時の環境変数一覧(クリックで展開します)</summary>
<pre>
<code>{
 "PATH": "/usr/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/app/node_modules/.bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 "RECORDEDID": "311",
 "VIDEOFILEID": "",
 "OUTPUTPATH": "null",
 "MODE": "enc_test",
 "NAME": "名探偵ポワロ（５９）「鳩（はと）のなかの猫」[二][字]",
 "HALF_WIDTH_NAME": "名探偵ポワロ(59)「鳩(はと)のなかの猫」[二][字]",
 "DESCRIPTION": "アガサ・クリスティーの人気作「名探偵ポワロ」をハイビジョンリマスター版で放送！名門女子校で起きた教師殺人事件。さらに学園の生徒で、ラマット国の王女が行方不明に。",
 "HALF_WIDTH_DESCRIPTION": "アガサ・クリスティーの人気作「名探偵ポワロ」をハイビジョンリマスター版で放送!名門女子校で起きた教師殺人事件。さらに学園の生徒で、ラマット国の王女が行方不明に。",
 "EXTENDED": "◇番組内容\n名門女子校のメドウバンクを訪れたポワロは、校長のバルストロードから「次期校長の人選で悩んでいるので助言してほしい」と頼まれ、しばらく学校に滞在することに。そんな中、体育教師のスプリンガーが、深夜に体育館で殺されるという事件が起きる。スプリンガーは嫌みな性格で、教師や生徒たちから好かれていなかった。さらに学園の生徒で政変が起きたラマット国から来た王女が行方不明になる。\n◇出演者\n【出演】デビッド・スーシェ…熊倉一雄，ハリエット・ウォルター…弥永和子，ナターシャ・リトル…田中敦子，アダム・クローズデル…家中宏，ピッパ・ヘイウッド…藤生聖子\n◇原作・脚本\n【原作】アガサ・クリスティー，【脚本】マーク・ゲイティス\n◇監督・演出\n【演出】ジェームズ・ケント\n◇制作\n～（イギリス・アメリカ）ＩＴＶプロダクション／ＷＧＢＨボストン／アガサ・クリスティー　Ｌｔｄ．制作～",
 "HALF_WIDTH_EXTENDED": "◇番組内容\n名門女子校のメドウバンクを訪れたポワロは、校長のバルストロードから「次期校長の人選で悩んでいるので助言してほしい」と頼まれ、しばらく学校に滞在することに。そんな中、体育教師のスプリンガーが、深夜に体育館で殺されるという事件が起きる。スプリンガーは嫌みな性格で、教師や生徒たちから好かれていなかった。さらに学園の生徒で政変が起きたラマット国から来た王女が行方不明になる。\n◇出演者\n【出演】デビッド・スーシェ…熊倉一雄,ハリエット・ウォルター…弥永和子,ナターシャ・リトル…田中敦子,アダム・クローズデル…家中宏,ピッパ・ヘイウッド…藤生聖子\n◇原作・脚本\n【原作】アガサ・クリスティー,【脚本】マーク・ゲイティス\n◇監督・演出\n【演出】ジェームズ・ケント\n◇制作\n~(イギリス・アメリカ)ITVプロダクション/WGBHボストン/アガサ・クリスティー Ltd.制作~",
 "CHANNELID": "400103",
 "CHANNELNAME": "ＮＨＫＢＳプレミアム",
 "HALF_WIDTH_CHANNELNAME": "NHKBSプレミアム"
}</code>
</pre>
</details>

（VIDEOFILEID、OUTPUTPATHがないのは非エンコードコマンドにて変数の確認を行ったためです。)

## 意図
V2.5.0で`encodingFinishCommand`が実装されたことで、今までencordコマンド内で行っていた処理を`encodingFinishCommand`で行うようになることが想定されるため。　
例としては
- エンコード後のファイルをEPGStationの管理外の場所へ番組別などに整理し、コピーする。
- クラウドサーバへ番組別などに整理し、アップロードする。（私の用途です。）
- エンコードの終了通知をSlackなどへ通知する。（私の用途です。）

があげられると思います。
ひとまず私の用途として利用する際にあれば便利だなと思う変数を用意しました。

変更内容の間違いや、変数の不足、`encodingFinishCommand`の想定していない使用方法であったりなどの問題があればご教示ください。

`encodingFinishCommand`は今までエンコード後にいろいろなスクリプトから呼んでいた処理を一括で管理することができ、とても魅力的な設定です。実装に感謝いたします。