### PR TITLE
v1の挙動と同じく番組表の日付変更時には開始時間を0時から始まるように変更

### DIFF
--- a/client/src/components/guide/GuideDaySelectDialog.vue
+++ b/client/src/components/guide/GuideDaySelectDialog.vue
@@ -69,12 +69,12 @@ export default class GuideDaySelectDialog extends Vue {
         // 日付
         this.dayItems = [];
         const now = DateUtil.getJaDate(new Date());
-        const hourStr = DateUtil.format(now, 'hh');
         let baseTime = new Date(DateUtil.format(now, 'yyyy/MM/dd 00:00:00 +0900')).getTime();
 
         const currentTime = typeof this.$route.query.time === 'string' ? this.$route.query.time : DateUtil.format(now, 'YYMMddhh');
 
         for (let i = 0; i < 8; i++) {
+            const hourStr = i === 0 ? DateUtil.format(now, 'hh') : '00';
             const date = new Date(baseTime);
             const value = DateUtil.format(date, 'YYMMdd' + hourStr);
             this.dayItems.push({


### PR DESCRIPTION
## 概要(Summary)

v2の番組表での日付変更の挙動が、v1の時と同じになるように変更しました。 
v1の時は #203 で提案されて実装されていました。
この0時への遷移はとても便利で、これがv2ではないことでいまだにv2に移行できずにいます。

ご検討いただけると幸いです:pray: