### PR TITLE
[Ubuntu-nvenc] 複数CCのGPUコード生成に対応、Docker Hubへのイメージ追加

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
         distro:
           - alpine
           - debian
+          - ubuntu-evenc
         include:
           - distro: alpine
             platforms: >-
@@ -26,6 +27,12 @@ jobs:
               linux/arm64/v8,
           - distro: debian
             # docker/setup-*-action has not supported linux/arm/v5.
+            platforms: >-
+              linux/amd64,
+              linux/arm/v7,
+              linux/arm64/v8,
+          - distro: ubuntu-evenc
+            # Nvidia Tegra X1 supports linux/arm64/v8, and Tegra K1 linux/arm/v7, but others are not known for now.
             platforms: >-
               linux/amd64,
               linux/arm/v7,

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
               linux/arm/v7,
               linux/arm64/v8,
           - distro: ubuntu-evenc
-            # Nvidia Tegra X1 supports linux/arm64/v8, and Tegra K1 linux/arm/v7, but others are not known for now.
+            # NVIDIA Tegra X1 supports linux/arm64/v8, and Tegra K1 linux/arm/v7, but others are not known for now.
             platforms: >-
               linux/amd64,
               linux/arm/v7,

--- a/Dockerfile.ubuntu-nvenc
+++ b/Dockerfile.ubuntu-nvenc
@@ -31,7 +31,8 @@ ENV USE_CCACHE=1
 ENV DEV="make gcc git g++ automake curl wget autoconf build-essential libass-dev libfreetype6-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo zlib1g-dev ccache"
 
 ENV FFMPEG_VERSION=4.2.4
-ENV CUDA_CC=52    
+# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list
+ENV CUDA_CC="35 50 52 53 60 61 62 70 72 75 80 86" 
 ENV NODE_VERSION 16
 
 RUN mkdir /opt/.ccache
@@ -55,6 +56,10 @@ RUN --mount=type=cache,target=/opt/.ccache \
 #ffmpeg build
     mkdir /tmp/ffmpeg_sources && \
     cd /tmp/ffmpeg_sources && \
+    ary=(`echo $CUDA_CC`) \
+    for i in `seq 1 ${#ary[@]}`; do  compute="compute_${ary[$i-1]},$compute"; done  \
+    for i in `seq 1 ${#ary[@]}`; do  sm="sm_${ary[$i-1]},$sm"; done \
+    CUDA_OPTION="-gencode arch=${compute}code=${sm} -O2" \
     curl -fsSL http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 | tar -xj --strip-components=1 && \
     ./configure \
       --prefix=/usr/local \
@@ -78,7 +83,7 @@ RUN --mount=type=cache,target=/opt/.ccache \
       --enable-cuda-nvcc --extra-cflags=-I/usr/local/cuda/include \
       --extra-ldflags=-L/usr/local/cuda/lib64 \
 # CC指定フラグ追加 (https://github.com/NVIDIA/cuda-samples/issues/46#issuecomment-863835984 より)
-      --nvccflags="-gencode arch=compute_${CUDA_CC},code=sm_${CUDA_CC} -O2" \
+      --nvccflags="${CUDA_OPTION}" \
 && \
     make -j$(nproc) && \
     make install && \

--- a/Dockerfile.ubuntu-nvenc
+++ b/Dockerfile.ubuntu-nvenc
@@ -32,7 +32,7 @@ ENV DEV="make gcc git g++ automake curl wget autoconf build-essential libass-dev
 
 ENV FFMPEG_VERSION=4.2.4
 # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list
-ENV CUDA_CC="35 50 52 53 60 61 62 70 72 75 80 86" 
+ENV CUDA_CC="35 37 50 52 53 60 61 62 70 72 75 80 86 87" 
 ENV NODE_VERSION 16
 
 RUN mkdir /opt/.ccache
@@ -47,7 +47,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
     apt-get -y install libasound2 libass9 libvdpau1 libva-x11-2 libva-drm2 libxcb-shm0 libxcb-xfixes0 libxcb-shape0 libvorbisenc2 libtheora0 libaribb24-dev && \
     apt-get -y install nodejs
 
-RUN --mount=type=cache,target=/opt/.ccache \
+SHELL ["/bin/bash", "-c"]
+
+RUN \
 #nvenc build
     git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git && \
     cd nv-codec-headers && make install && cd .. && \
@@ -56,11 +58,11 @@ RUN --mount=type=cache,target=/opt/.ccache \
 #ffmpeg build
     mkdir /tmp/ffmpeg_sources && \
     cd /tmp/ffmpeg_sources && \
-    ary=(`echo $CUDA_CC`) \
-    for i in `seq 1 ${#ary[@]}`; do  compute="compute_${ary[$i-1]},$compute"; done  \
-    for i in `seq 1 ${#ary[@]}`; do  sm="sm_${ary[$i-1]},$sm"; done \
-    CUDA_OPTION="-gencode arch=${compute}code=${sm} -O2" \
+    ary=(`echo $CUDA_CC`) && \
+    for i in `seq 1 ${#ary[@]}`;  do    gencode="-gencode arch=compute_${ary[$i-1]},code=sm_${ary[$i-1]} $gencode"; done && \
+    CUDA_OPTION="-arch sm_52 ${gencode} -O2" && \
     curl -fsSL http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 | tar -xj --strip-components=1 && \
+    sed -i -e 's/$nvccflags -ptx/$nvccflags/g' ./configure && \
     ./configure \
       --prefix=/usr/local \
       --disable-shared \
@@ -80,6 +82,9 @@ RUN --mount=type=cache,target=/opt/.ccache \
       --enable-nonfree \
       --disable-debug \
       --disable-doc \
+# ccache有効
+      --cc="ccache cc" --cxx="ccache c++" \
+# CUDA Toolkit
       --enable-cuda-nvcc --extra-cflags=-I/usr/local/cuda/include \
       --extra-ldflags=-L/usr/local/cuda/lib64 \
 # CC指定フラグ追加 (https://github.com/NVIDIA/cuda-samples/issues/46#issuecomment-863835984 より)
@@ -98,6 +103,7 @@ RUN --mount=type=cache,target=/opt/.ccache \
 LABEL maintainer="l3tnun"
 COPY --from=server-builder /app /app/
 COPY --from=client-builder /app/client /app/client/
+RUN chmod 444 /app/src -R
 EXPOSE 8888
 WORKDIR /app
 ENTRYPOINT ["npm"]


### PR DESCRIPTION
## 概要(Summary)

- 環境変数CUDA_CCへスペース区切りで値を与えることで("52 60 62 70")、複数種類のGPUに対応できるようにしました。
- デフォルトでCUDA Toolkitが対応するすべてのCCを指定しています
- ActionsからDocker Hubへプッシュするタスクにubuntu-nvencを試験的に追加しました。(Actionsについてはこちらでのテストはできていません)
