### PR TITLE
放映中ページにて放送種別切り替え時にスクロール位置をリセットするように変更

### DIFF
--- a/client/src/views/OnAir.vue
+++ b/client/src/views/OnAir.vue
@@ -94,6 +94,11 @@ export default class OnAir extends Vue {
         });
     }
 
+    @Watch('onAirState.selectedTab')
+    onTabChanged(): void {
+        window.scroll(0, 0);
+    }
+
     /**
      * 番組データ取得
      * @return Promise<void>


### PR DESCRIPTION
## 概要(Summary)

- Fixed #530 
- 放映中ページにて放送種別切り替え時にスクロール位置が一番上にもどるように変更しました
