### PR TITLE
fix: iPadOS 15.1 の Safari/604.1 を正しく判定できるように修正

### DIFF
--- a/client/src/util/UaUtil.ts
+++ b/client/src/util/UaUtil.ts
@@ -3,7 +3,7 @@ namespace UaUtil {
      * UA が iPadOS か判定
      */
     export const isiPadOS = (): boolean => {
-        return /Macintosh|macintosh/.test(navigator.userAgent) === true && 'ontouchend' in document;
+        return /iPad|Macintosh|macintosh/.test(navigator.userAgent) === true && 'ontouchend' in document;
     };
 
     /**


### PR DESCRIPTION
## 概要(Summary)

iPad mini 6 (iPad OS 15.1) の Safari/604.1 で m2ts-ll など iOS では使えないが iPadOS では使える機能が使えなかったので調査しましたが、UA による判定がうまくいっていないようでした。
https://github.com/l3tnun/EPGStation/blob/b4e9cd6f3405215974c34751b6a15c968d996162/client/src/util/UaUtil.ts#L6

正規表現のパターンに `iPad` を追加し、正しく動く事を確認しました。

### 補足情報

モバイルモード(通常)の UA は
```
Mozilla/5.0 (iPad; CPU OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Mobile/15E148 Safari/604.1
```
です。

デスクトップモードの UA は
```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
```
です。

どちらのモードでも `'ontouchend' in document` は `true` でした。
