### PR TITLE
削除する録画データが0件の場合は早期リターンをするように変更

### DIFF
--- a/client/src/components/recorded/RecordedDeleteDialog.vue
+++ b/client/src/components/recorded/RecordedDeleteDialog.vue
@@ -97,6 +97,13 @@ export default class RecordedDeleteDialog extends Vue {
     public async deleteRecorded(): Promise<void> {
         this.dialogModel = false;
 
+        // 削除対象が0件の場合は早期リターンをする
+        let isNoDelete = false;
+        isNoDelete = this.videoFiles.every(v => v.isDelete === false);
+        if (isNoDelete) {
+            return;
+        }
+
         try {
             const needsPageback = await this.delete();
             this.$nextTick(async () => {


### PR DESCRIPTION
## 概要(Summary)
- 録画データ削除ダイアログ（`RecordedDeleteDialog.vue`）にて、削除する録画データが0件（`isDelete`が全て`false`）だった場合は`delete` メソッドを発火させる前に早期リターンをする変更を加えました。
- 修正の経緯はIssue  #567 をご確認いただけると幸いです。