### PR TITLE
Stream取得失敗時にリトライされない問題を修正

### DIFF
--- a/src/model/operator/recording/RecorderModel.ts
+++ b/src/model/operator/recording/RecorderModel.ts
@@ -387,8 +387,6 @@ class RecorderModel implements IRecorderModel {
         }).catch(err => {
             // 予想外の録画失敗エラー
             this.destroyStream();
-            // 録画失敗を通知
-            this.recordingEvent.emitPrepRecordingFailed(this.reserve);
             throw err;
         });
     }


### PR DESCRIPTION
## 概要(Summary)

Stream取得でタイムアウトして失敗した際、リトライする前に予約がキャンセルされてしまうため想定通り動かない（リトライがされない）問題があります。
不要と思われるイベント通知処理を削除しました。

## 詳細
具体的には `RecorderModel#doRecord()` L391において、例外捕捉直後に失敗イベントを投げているためこの中でキャンセルされてしまっているようです。
この L391の `emitPrepRecordingFailed()`は `doRecord()` の呼び出し元である `prepRecord()`, L190で最終的に呼び出されているのでL391でのイベント通知は不要のように思いました。
（本来は閾値である３回を超えて失敗するとL190で予約キャンセルがされ、最終的に「失敗」で終了する・・・というのが本来想定していた動作かなと思いました）

以下、修正前後のログになります。
考慮漏れ等ないか確認いただけると助かります。

よろしくお願いします。


#### 修正前：１回目に落ちた直後に予約がキャンセルされるのでリトライできていない
```
[2022-02-24T00:59:45.002] [INFO] system - preprec: 1116
[2022-02-24T01:00:05.139] [INFO] system - recording: 1116 /mnt/hdd1/Recordings/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts
[2022-02-24T01:00:05.173] [INFO] system - add drop log file: /home/pi/tv/EPGStation/drop/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts.log
[2022-02-24T01:00:10.197] [ERROR] system - recording failed: 1116
[2022-02-24T01:00:10.200] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts.log
[2022-02-24T01:00:10.214] [ERROR] system - RecordingStreamCreator stream error: 1116
[2022-02-24T01:00:10.214] [ERROR] system - drop log check stream error: /mnt/hdd1/Recordings/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts
[2022-02-24T01:00:10.214] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts.log
[2022-02-24T01:00:15.665] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts.log
[2022-02-24T01:00:15.668] [INFO] system - cancel reservation: 1116
[2022-02-24T01:00:15.668] [ERROR] system - preprec failed: 1116
[2022-02-24T01:00:15.669] [ERROR] system - Error: recordingStartError
    at RecorderModel.<anonymous> (/home/pi/tv/EPGStation/dist/model/operator/recording/model/operator/recording/RecorderModel.ts:353:24)
    at Generator.next (<anonymous>)
    at fulfilled (/home/pi/tv/EPGStation/dist/model/operator/recording/RecorderModel.js:36:58)
[2022-02-24T01:00:15.855] [INFO] system - { insert: 0, update: 0, delete: 1 }
[2022-02-24T01:00:15.861] [INFO] system - successful cancel reservation: 1116
[2022-02-24T01:00:20.841] [INFO] system - preprec: 1116
[2022-02-24T01:00:23.058] [ERROR] system - canceled preprec: 1116
[2022-02-24T01:00:23.061] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-01時00分-ＢＳ１スペシャル「“コロナ　メンタルクライシス”」[字][再].ts.log
[2022-02-24T01:00:23.068] [ERROR] system - RecordingStreamCreator stream error: 1116
```


 #### 修正後：一度失敗する（19:50:13）が、その後リトライ（19:50:18）して録画開始（19:50:21）している
```
[2022-02-24T19:49:45.002] [INFO] system - preprec: 1131
[2022-02-24T19:50:03.225] [INFO] system - recording: 1131 /mnt/hdd1/Recordings/2022年02月24日-19時50分-ＢＳニュース.ts
[2022-02-24T19:50:03.246] [INFO] system - add drop log file: /home/pi/tv/EPGStation/drop/2022年02月24日-19時50分-ＢＳニュース.ts.log
[2022-02-24T19:50:08.255] [ERROR] system - recording failed: 1131
[2022-02-24T19:50:08.258] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-19時50分-ＢＳニュース.ts.log
[2022-02-24T19:50:08.291] [ERROR] system - RecordingStreamCreator stream error: 1131
[2022-02-24T19:50:08.292] [ERROR] system - drop log check stream error: /mnt/hdd1/Recordings/2022年02月24日-19時50分-ＢＳニュース.ts
[2022-02-24T19:50:08.292] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-19時50分-ＢＳニュース.ts.log
[2022-02-24T19:50:13.730] [INFO] system - stop drop check: /home/pi/tv/EPGStation/drop/2022年02月24日-19時50分-ＢＳニュース.ts.log
[2022-02-24T19:50:13.731] [ERROR] system - preprec failed: 1131
[2022-02-24T19:50:13.732] [ERROR] system - Error: recordingStartError
    at RecorderModel.<anonymous> (/home/pi/tv/EPGStation/dist/model/operator/recording/model/operator/recording/RecorderModel.ts:353:24)
    at Generator.next (<anonymous>)
    at fulfilled (/home/pi/tv/EPGStation/dist/model/operator/recording/RecorderModel.js:36:58)
[2022-02-24T19:50:18.922] [INFO] system - preprec: 1131
[2022-02-24T19:50:21.731] [INFO] system - recording: 1131 /mnt/hdd1/Recordings/2022年02月24日-19時50分-ＢＳニュース.ts
[2022-02-24T19:50:21.746] [INFO] system - add drop log file: /home/pi/tv/EPGStation/drop/2022年02月24日-19時50分-ＢＳニュース.ts(1).log
[2022-02-24T19:50:21.759] [INFO] system - add recorded 1131 /mnt/hdd1/Recordings/2022年02月24日-19時50分-ＢＳニュース.ts
[2022-02-24T19:50:21.781] [INFO] system - recording added reserveId: 1131, recordedId: 1349
[2022-02-24T19:50:21.782] [INFO] system - create video file: 2022年02月24日-19時50分-ＢＳニュース.ts
[2022-02-24T19:50:21.796] [INFO] system - set stream.finished: reserveId: 1131 recordedId: 1349
```