### PR TITLE
feat: IPTV チャンネルリストに ARIB で定義されるサービスも表示

### DIFF
--- a/src/model/api/iptv/IPTVApiModel.ts
+++ b/src/model/api/iptv/IPTVApiModel.ts
@@ -7,6 +7,7 @@ import DateUtil from '../../../util/DateUtil';
 import IChannelDB from '../../db/IChannelDB';
 import IProgramDB from '../../db/IProgramDB';
 import IIPTVApiModel from './IIPTVApiModel';
+import ChannelUtil from '../../../util/ChannelUtil';
 
 @injectable()
 class IPTVApiModel implements IIPTVApiModel {
@@ -33,7 +34,7 @@ class IPTVApiModel implements IIPTVApiModel {
 
         let str = '#EXTM3U\n';
         for (const channel of channels) {
-            if (channel.type !== 1) {
+            if (!ChannelUtil.isMediaService(channel.type)) {
                 continue;
             }
 

--- a/src/util/ChannelUtil.ts
+++ b/src/util/ChannelUtil.ts
@@ -1,0 +1,30 @@
+namespace ChannelUtil {
+    /**
+     * 映像・音声サービスであるかを返す
+     * @param serviceType: number 対象のサービスタイプ
+     * @see https://github.com/DBCTRADO/LibISDB/blob/master/LibISDB/LibISDBConsts.hpp#L122
+     */
+    export const isMediaService = (serviceType: number): boolean => {
+        switch (serviceType) {
+            // デジタルTVサービス
+            case 0x01:
+            // デジタル音声サービス
+            case 0x02:
+            // 臨時映像サービス
+            case 0xa1:
+            // 臨時音声サービス
+            case 0xa2:
+            // プロモーション映像サービス
+            case 0xa5:
+            // プロモーション音声サービス
+            case 0xa6:
+            // 超高精細度4K専用TVサービス
+            case 0xad:
+                return true;
+            default:
+                return false;
+        }
+    };
+}
+
+export default ChannelUtil;


### PR DESCRIPTION
## 概要(Summary)

- 従来のIPTV チャンネルリスト (`/iptv/channel.m3u8`) に含まれるサービスは `0x01` のデジタル TV サービスのみでした
- この PR は、ARIB 仕様で定義されている他の映像・音声サービスもリストに含めるように変更しました
  - 具体的には、BS の放送大学ラジオや、一部のケーブルテレビの自主放送 (ケーブル4K) などが含まれるようになります
  - ワンセグや、再生不可能なデータサービス・エンジニアリングサービス等は従来通り含まれません
  - プロモーションサービスが追加されますが、スカパープロモなど対象とならず、一般に利用されていないようです
  - ARIB の定義については https://github.com/DBCTRADO/LibISDB/blob/master/LibISDB/LibISDBConsts.hpp#L122 を参照ください

よろしくおねがいします