### PR TITLE
chore: 映像・音声サービスではないチャンネルを番組表から除外

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -37,6 +37,7 @@ export interface ChannelItem {
     hasLogoData: boolean;
     channelType: ChannelType;
     channel: string;
+    type?: number;
 }
 
 /**
@@ -561,6 +562,7 @@ export interface ScheduleChannleItem {
     remoteControlKeyId?: number;
     hasLogoData: boolean;
     channelType: ChannelType;
+    type?: number;
 }
 
 /**

--- a/api.yml
+++ b/api.yml
@@ -352,6 +352,8 @@ components:
                     $ref: '#/components/schemas/ChannelType'
                 channel:
                     type: string
+                type:
+                    type: number
 
         ScheduleChannleItem:
             description: 番組表の放送局データ
@@ -380,6 +382,8 @@ components:
                     type: boolean
                 channelType:
                     $ref: '#/components/schemas/ChannelType'
+                type:
+                    type: number
 
         ScheduleProgramItem:
             description: 番組表の番組データ

--- a/client/src/model/channels/ChannelModel.ts
+++ b/client/src/model/channels/ChannelModel.ts
@@ -19,11 +19,34 @@ export default class ChannelModel implements IChannelModel {
      */
     public async fetchChannels(): Promise<void> {
         this.channels = await this.channelsApiModel.getChannels();
+        this.channels = this.channels.filter(c => ChannelModel.isAudioVideoService(c.type));
 
         // 索引作成
         this.channelsIndex = {};
         for (const c of this.channels) {
             this.channelsIndex[c.id] = c;
+        }
+    }
+
+    /**
+     * 映像・音声サービスであるかを返す
+     * @param serviceType: number? 対象のサービスタイプ
+     * @see https://github.com/DBCTRADO/LibISDB/blob/master/LibISDB/LibISDBConsts.hpp#L122
+     */
+    public static isAudioVideoService(serviceType?: number): boolean {
+        switch (serviceType) {
+            case 0x01:
+            case 0x02:
+            case 0xa1:
+            case 0xa2:
+            case 0xa5:
+            case 0xa6:
+            case 0xad:
+            case null:
+            case undefined:
+                return true;
+            default:
+                return false;
         }
     }
 
@@ -53,6 +76,7 @@ export default class ChannelModel implements IChannelModel {
             hasLogoData: item.hasLogoData,
             channelType: item.channelType,
             channel: item.channelType,
+            type: item.type,
         };
     }
 

--- a/client/src/model/state/guide/GuideState.ts
+++ b/client/src/model/state/guide/GuideState.ts
@@ -1,3 +1,4 @@
+import ChannelModel from '@/model/channels/ChannelModel';
 import { IGuideGenreSettingStorageModel, IGuideGenreSettingValue } from '@/model/storage/guide/IGuideGenreSettingStorageModel';
 import { inject, injectable } from 'inversify';
 import * as apid from '../../../../../api';
@@ -117,6 +118,7 @@ class GuideState implements IGuideState {
             }
 
             this.schedules = await this.scheduleApiModel.getSchedules(scheduleOption);
+            this.schedules = this.schedules.filter(s => ChannelModel.isAudioVideoService(s.channel.type));
         } else {
             // 放送局指定
             this.timeLength = GuideState.SINGLE_STATION_LENGTH;

--- a/src/model/api/channel/ChannelApiModel.ts
+++ b/src/model/api/channel/ChannelApiModel.ts
@@ -35,6 +35,7 @@ class ChannelApiModel implements IChannelApiModel {
                 hasLogoData: c.hasLogoData,
                 channelType: <any>c.channelType,
                 channel: c.channel,
+                type: c.type,
             };
 
             if (c.remoteControlKeyId !== null) {

--- a/src/model/api/schedule/ScheduleApiModel.ts
+++ b/src/model/api/schedule/ScheduleApiModel.ts
@@ -303,6 +303,7 @@ export default class ScheduleApiModel implements IScheduleApiModel {
             name: isHalfWidth ? channel.halfWidthName : channel.name,
             hasLogoData: channel.hasLogoData,
             channelType: <any>channel.channelType,
+            type: channel.type,
         };
 
         if (channel.remoteControlKeyId !== null) {


### PR DESCRIPTION
## 概要(Summary)

番組表から映像・音声サービスではないチャンネルを除外しました。
データ放送専用チャンネルなどが表示されなくなります。
サービスの判定は #592 に準じます。

Signed-off-by: SlashNephy <spica@starry.blue>