### PR TITLE
Hotfix: IPTV Simple Client is very slow.

### DIFF
--- a/src/model/api/iptv/IPTVApiModel.ts
+++ b/src/model/api/iptv/IPTVApiModel.ts
@@ -58,6 +58,7 @@ class IPTVApiModel implements IIPTVApiModel {
             if (channel.hasLogoData) {
                 logo = `tvg-logo="${isSecure ? 'https' : 'http'}://${base}/api/channels/${channel.id}/logo"`;
             }
+            str += `#KODIPROP:mimetype=video/mp2t\n`;
             str += `#EXTINF:-1 tvg-id="${channel.id}" ${logo} group-title="${channel.channelType}",${channelName}　\n`;
             str += `${isSecure ? 'https' : 'http'}://${base}/api/streams/live/${channel.id}/m2ts?mode=${mode}\n`;
         }


### PR DESCRIPTION
## 概要(Summary)
[IPTV Simple Client との連携](https://github.com/l3tnun/EPGStation/blob/v2/doc/kodi.md#iptv-simple-client-%E3%81%A8%E3%81%AE%E9%80%A3%E6%90%BA)でチャンネル切替(初回選択を含む)に40秒ほどかかりる現象が発生します。

クライアントのログを確認しましたが、下記のようにTimeoutが発生しています。

```text
09-11 15:14:22.046  7246  7268 E Kodi    : 2022-09-11 15:14:22.046 T:7268    ERROR <general>: CCurlFile::Exists - Failed: Timeout was reached(28) for http://192.168.1.3:8888/api/streams/live/3274101064/m2ts?mode=2
```

[KODIのサポート](https://forum.kodi.tv/showthread.php?tid=368010&pid=3095694#pid3095694) で見つけた、m3u8の各エントリーに下記を追加する方法で解決できました。
```
#KODIPROP:mimetype=video/mp2t
```
約4秒でチャンネルが切り替わるようになりました。
- Fixed #613
