### PR TITLE
feat: サブディレクトリにフォーマット文字列置換を適用

### DIFF
--- a/src/model/operator/recorded/RecordedManageModel.ts
+++ b/src/model/operator/recorded/RecordedManageModel.ts
@@ -21,6 +21,7 @@ import ILogger from '../../ILogger';
 import ILoggerModel from '../../ILoggerModel';
 import IRecordingManageModel from '../recording/IRecordingManageModel';
 import IRecordedManageModel, { AddVideoFileOption, UploadedVideoFileOption } from './IRecordedManageModel';
+import IRecordingUtilModel from '../recording/IRecordingUtilModel';
 
 @injectable()
 export default class RecordedManageModel implements IRecordedManageModel {
@@ -34,6 +35,7 @@ export default class RecordedManageModel implements IRecordedManageModel {
     private recordingManageModel: IRecordingManageModel;
     private recordedEvent: IRecordedEvent;
     private videoUtil: IVideoUtil;
+    private recordingUtilModel: IRecordingUtilModel;
 
     constructor(
         @inject('ILoggerModel') logger: ILoggerModel,
@@ -47,6 +49,7 @@ export default class RecordedManageModel implements IRecordedManageModel {
         recordingManageModel: IRecordingManageModel,
         @inject('IRecordedEvent') recordedEvent: IRecordedEvent,
         @inject('IVideoUtil') videoUtil: IVideoUtil,
+        @inject('IRecordingUtilModel') recordingUtilModel: IRecordingUtilModel,
     ) {
         this.log = logger.getLogger();
         this.config = configuration.getConfig();
@@ -58,6 +61,7 @@ export default class RecordedManageModel implements IRecordedManageModel {
         this.recordingManageModel = recordingManageModel;
         this.recordedEvent = recordedEvent;
         this.videoUtil = videoUtil;
+        this.recordingUtilModel = recordingUtilModel;
     }
 
     /**
@@ -278,7 +282,10 @@ export default class RecordedManageModel implements IRecordedManageModel {
         // サブディレクトリ
         let dirPath = parentDirPath;
         if (typeof option.subDirectory !== 'undefined') {
-            dirPath = path.join(dirPath, option.subDirectory);
+            dirPath = path.join(
+                dirPath,
+                await this.recordingUtilModel.formatFilePathString(option.subDirectory, recorded),
+            );
 
             // check dir
             try {
@@ -317,7 +324,12 @@ export default class RecordedManageModel implements IRecordedManageModel {
                 recordedId: option.recordedId,
                 parentDirectoryName: option.parentDirectoryName,
                 filePath:
-                    typeof option.subDirectory === 'undefined' ? fileName : path.join(option.subDirectory, fileName),
+                    typeof option.subDirectory === 'undefined'
+                        ? fileName
+                        : path.join(
+                              await this.recordingUtilModel.formatFilePathString(option.subDirectory, recorded),
+                              fileName,
+                          ),
                 type: option.fileType,
                 name: option.viewName,
             });

--- a/src/model/operator/recording/IRecordingUtilModel.ts
+++ b/src/model/operator/recording/IRecordingUtilModel.ts
@@ -1,5 +1,6 @@
 import * as apid from '../../../../api';
 import Reserve from '../../../db/entities/Reserve';
+import Recorded from '../../../db/entities/Recorded';
 import { RecordedDirInfo } from '../../IConfigFile';
 
 export interface RecFilePathInfo {
@@ -13,4 +14,5 @@ export default interface IRecordingUtilModel {
     getRecPath(reserve: Reserve, isEnableTmp: boolean): Promise<RecFilePathInfo>;
     movingFromTmp(reserve: Reserve, videoFileId: apid.VideoFileId): Promise<string>;
     updateVideoFileSize(videoFileId: apid.VideoFileId): Promise<void>;
+    formatFilePathString(format: string | null | undefined, src: Recorded | Reserve): Promise<string>;
 }


### PR DESCRIPTION
## 概要(Summary)

録画ディレクトリのサブディレクトリ指定文字列、エンコードディレクトリのサブディレクトリ指定文字列について、ファイル名と同様のフォーマット文字列置換を適用します。

エンコード用のサブディレクトリは、エンコード時には `Reserve` エンティティが削除済で参照できないため、代わりに `Recorded` エンティティから置換しています。
そのため、ロジックを切り出したメソッドの引数が `Recorded | Reserve` になっています。


