### PR TITLE
fix: 録画検索時のクエリパラメータを修正

### DIFF
--- a/client/src/components/recorded/RecordedSearchMenu.vue
+++ b/client/src/components/recorded/RecordedSearchMenu.vue
@@ -94,10 +94,10 @@ export default class RecordedSearchMenu extends Vue {
             } else if (typeof this.searchState.ruleId !== 'undefined' && this.searchState.ruleId !== null) {
                 searchQuery.ruleId = this.searchState.ruleId;
             }
-            if (typeof this.searchState.channelId !== 'undefined') {
+            if (typeof this.searchState.channelId !== 'undefined' && this.searchState.channelId !== null) {
                 searchQuery.channelId = this.searchState.channelId;
             }
-            if (typeof this.searchState.genre !== 'undefined') {
+            if (typeof this.searchState.genre !== 'undefined' && this.searchState.genre !== null) {
                 searchQuery.genre = this.searchState.genre;
             }
             if (this.searchState.hasOriginalFile === true) {


### PR DESCRIPTION
## 概要(Summary)

録画検索時のパラメータについて、「放送局」「ジャンル」をフィールドのクリアボタンにて空にしてから検索するとエラーになります。
その際、URLクエリ文字列は `/#/recorded?genre&channelid&timestamp=1699760905709` のようになっており、`null` でクエリしているからだと思われます。
コードでは `undefined` 時のみパラメータを追加しないようになっていたので、`this.searchState.ruleId` と同様に `null` 時も追加しないように修正しました。

`keyword` パラメータについても同様のクエリ文字列になりますが、こちらはエラーにならないようでしたので修正していません。