### PR TITLE
番組の開始または終了時刻変更への追随性改善

### DIFF
--- a/src/model/ModelContainer.ts
+++ b/src/model/ModelContainer.ts
@@ -3,6 +3,6 @@ import { Container } from 'inversify';
 /**
  * container に 各 Model を登録する
  */
-const container = new Container();
+const container = new Container({ skipBaseClassChecks: true });
 
 export default container;

--- a/src/model/epgUpdater/EPGUpdater.ts
+++ b/src/model/epgUpdater/EPGUpdater.ts
@@ -5,6 +5,7 @@ import ILogger from '../ILogger';
 import ILoggerModel from '../ILoggerModel';
 import IEPGUpdateManageModel from './IEPGUpdateManageModel';
 import IEPGUpdater from './IEPGUpdater';
+import Util from '../../util/Util';
 
 @injectable()
 class EPGUpdater implements IEPGUpdater {
@@ -13,6 +14,9 @@ class EPGUpdater implements IEPGUpdater {
     private updateManage: IEPGUpdateManageModel;
 
     private isEventStreamAlive: boolean = false;
+    private lastUpdatedTime: number = 0;
+    private lastDeletedTime: number = 0;
+    private retryCount: number = 0;
 
     constructor(
         @inject('ILoggerModel') logger: ILoggerModel,
@@ -22,6 +26,34 @@ class EPGUpdater implements IEPGUpdater {
         this.log = logger.getLogger();
         this.config = configuration.getConfig();
         this.updateManage = updateManage;
+
+        this.updateManage.on('program updated', () => {
+            this.lastUpdatedTime = new Date().getTime();
+            this.notify();
+        });
+
+        this.updateManage.on('service updated', () => {
+            this.notify();
+        });
+
+        this.updateManage.on('event stream started', async () => {
+            this.log.system.info('event stream started');
+            this.retryCount = 0;
+            try {
+                await this.updateManage.updateAll();
+                this.notify();
+            } catch (err: any) {
+                this.log.system.error('updateAll error');
+            }
+            // updateAllが完了して以降、queueフラッシュ処理を有効にするために
+            // この位置でisEventStreamAliveをtrueにする
+            this.isEventStreamAlive = true;
+        });
+
+        this.updateManage.on('event stream aborted', () => {
+            this.log.system.info('has disconnected from the mirakurun');
+            this.isEventStreamAlive = false;
+        });
     }
 
     /**
@@ -29,47 +61,50 @@ class EPGUpdater implements IEPGUpdater {
      */
     public async start(): Promise<void> {
         this.log.system.info('start EPG update');
+
+        const updateInterval = this.config.epgUpdateIntervalTime * 60 * 1000;
+
+        // event streamを開始
         this.startEventStreamAnalysis();
-        await this.updateManage.updateAll().catch(err => {
-            this.log.system.fatal('epg initialization update error');
-            throw err;
-        });
-        this.notify();
 
-        const updateTime = this.config.epgUpdateIntervalTime;
-        setInterval(
-            async () => {
+        // 溜め込んだservice queueを設定ファイルで指定されたサイクルでDBへ保存
+        setInterval(async () => {
+            if (this.isEventStreamAlive === true) {
                 try {
-                    if (this.isEventStreamAlive === true) {
-                        if (this.updateManage.getServiceQueueSize() > 0) {
-                            // queue に更新情報が無ければ実行しない
-                            await this.updateManage.saveSevice();
-                        }
-                        if (this.updateManage.getProgramQueueSize() > 0) {
-                            // queue に更新情報が無ければ実行しない
-                            await this.updateManage.saveProgram();
-                        }
-                    } else {
-                        // stream event に何らかの問題が発生した
-                        this.startEventStreamAnalysis();
-                        await this.updateManage.updateAll();
-                    }
+                    await this.updateManage.saveService();
+                } catch (err: any) {
+                    this.log.system.error('service update error');
+                    this.log.system.error(err);
+                }
+            }
+        }, updateInterval);
 
-                    this.notify();
+        // 放送中や放送開始時刻が間近の番組は短いサイクルでDBへ保存する
+        // NOTE: DB負荷などを考慮しEvent受信と同時のDB反映は見合わせる
+        setInterval(async () => {
+            if (this.isEventStreamAlive === true) {
+                const now = new Date().getTime();
+                try {
+                    await this.updateManage.saveProgram(now + 5 * 60 * 1000);
+                    if (this.lastUpdatedTime + updateInterval <= now) {
+                        await this.updateManage.saveProgram();
+                        this.lastUpdatedTime = now;
+                    }
                 } catch (err: any) {
                     this.log.system.error('EPG update error');
                     this.log.system.error(err);
                 }
 
-                // 古い番組情報を削除
-                this.log.system.info('delete old programs');
-                await this.updateManage.deleteOldPrograms().catch(err => {
-                    this.log.system.error('delete old programs error');
-                    this.log.system.error(err);
-                });
-            },
-            updateTime * 60 * 1000,
-        );
+                if (this.lastDeletedTime + updateInterval <= now) {
+                    // 古い番組情報を削除
+                    await this.updateManage.deleteOldPrograms().catch(err => {
+                        this.log.system.error('delete old programs error');
+                        this.log.system.error(err);
+                    });
+                    this.lastDeletedTime = now;
+                }
+            }
+        }, 10 * 1000);
     }
 
     /**
@@ -77,12 +112,16 @@ class EPGUpdater implements IEPGUpdater {
      * stream に問題が発生した場合は this.isEventStreamAlive が false になる
      */
     private async startEventStreamAnalysis(): Promise<void> {
-        this.isEventStreamAlive = true;
-        try {
-            await this.updateManage.start();
-        } catch (err: any) {
-            this.log.system.error('destroy event stream');
-            this.isEventStreamAlive = false;
+        while (true) {
+            try {
+                this.log.system.info('trying to connecting to the mirakurun');
+                await this.updateManage.start();
+            } catch (err: any) {
+                this.log.system.error('destroy event stream');
+                this.retryCount++;
+                const retryInterval = Math.min(this.retryCount * 5 * 1000, 60 * 1000);
+                await Util.sleep(retryInterval);
+            }
         }
     }
 

--- a/src/model/epgUpdater/IEPGUpdateManageModel.ts
+++ b/src/model/epgUpdater/IEPGUpdateManageModel.ts
@@ -1,5 +1,9 @@
+import { EventEmitter } from 'events';
 import * as mapid from '../../../node_modules/mirakurun/api';
 
+export interface RemoveProgram {
+    id: mapid.ProgramId;
+}
 export interface RedefineProgram {
     from: mapid.ProgramId;
     to: mapid.ProgramId;
@@ -7,7 +11,7 @@ export interface RedefineProgram {
 
 export interface ProgramBaseEvent extends mapid.Event {
     resource: 'program';
-    data: RedefineProgram | mapid.Program;
+    data: RedefineProgram | RemoveProgram | mapid.Program;
 }
 
 export interface CreateEvent extends ProgramBaseEvent {
@@ -20,6 +24,11 @@ export interface UpdateEvent extends ProgramBaseEvent {
     data: mapid.Program;
 }
 
+export interface RemoveEvent extends ProgramBaseEvent {
+    type: 'remove';
+    data: RemoveProgram;
+}
+
 export interface RedefineEvent extends ProgramBaseEvent {
     type: 'remove';
     data: RedefineProgram;
@@ -30,13 +39,13 @@ export interface ServiceEvent extends mapid.Event {
     data: mapid.Service;
 }
 
-export default interface IEPGUpdateManageModel {
+export default interface IEPGUpdateManageModel extends EventEmitter {
     updateAll(): Promise<void>;
     updateChannels(): Promise<void>;
     start(): Promise<void>;
     getProgramQueueSize(): number;
     getServiceQueueSize(): number;
-    saveProgram(): Promise<void>;
+    saveProgram(timeThreshold?: number): Promise<void>;
     deleteOldPrograms(): Promise<void>;
-    saveSevice(): Promise<void>;
+    saveService(): Promise<void>;
 }

--- a/src/model/operator/recording/IRecordingStreamCreator.ts
+++ b/src/model/operator/recording/IRecordingStreamCreator.ts
@@ -4,7 +4,7 @@ import Reserve from '../../../db/entities/Reserve';
 
 interface IRecordingStreamCreator {
     setTuner(tuners: mapid.TunerDevice[]): void;
-    create(reserve: Reserve): Promise<http.IncomingMessage>;
+    create(reserve: Reserve, abortSignal: AbortSignal): Promise<http.IncomingMessage>;
     changeEndAt(reserve: Reserve): void;
 }
 

--- a/src/model/operator/recording/RecorderModel.ts
+++ b/src/model/operator/recording/RecorderModel.ts
@@ -63,6 +63,8 @@ class RecorderModel implements IRecorderModel {
 
     private dropLogFileId: apid.DropLogFileId | null = null;
 
+    private abortController: AbortController | null = null;
+
     constructor(
         @inject('ILoggerModel') logger: ILoggerModel,
         @inject('IConfiguration') configuration: IConfiguration,
@@ -141,10 +143,8 @@ class RecorderModel implements IRecorderModel {
      */
     private async prepRecord(retry: number = 0): Promise<void> {
         if (this.isStopPrepRec === true) {
-            this.isStopPrepRec = false;
-            this.isPrepRecording = false;
-            this.isRecording = false;
             this.isPlanToDelete = false;
+            this.emitCancelEvent();
 
             return;
         }
@@ -162,7 +162,21 @@ class RecorderModel implements IRecorderModel {
 
         // 番組ストリームを取得する
         try {
-            this.stream = await this.streamCreator.create(this.reserve);
+            // 番組開始時刻が変更されたことに伴い番組間に重なりが生じ、当該番組が削除されている
+            // NOTE: mirakurunの不具合に対処
+            if (this.reserve.programId) {
+                const program = await this.programDB.findId(this.reserve.programId);
+                if (program === null) {
+                    this.log.system.warn(
+                        `the program data does not found in database. retry later, (reerveId: ${this.reserve.id}, programId: ${this.reserve.programId})`,
+                    );
+                    this.emitCancelEvent();
+                    return;
+                }
+            }
+
+            this.abortController = new AbortController();
+            this.stream = await this.streamCreator.create(this.reserve, this.abortController.signal);
 
             // 録画準備のキャンセル or ストリーム取得中に予約が削除されていないかチェック
             if ((await this.reserveDB.findId(this.reserve.id)) === null) {
@@ -173,13 +187,15 @@ class RecorderModel implements IRecorderModel {
                 await this.doRecord();
             }
         } catch (err: any) {
+            if ((this.isStopPrepRec as any) === true) {
+                this.destroyStream();
+                this.emitCancelEvent();
+                return;
+            }
+
             this.log.system.error(`preprec failed: ${this.reserve.id}`);
             this.log.system.error(err);
-            if ((this.isStopPrepRec as any) === true) {
-                this.emitCancelEvent();
-
-                return;
-            } else if (retry < 3) {
+            if (retry < 3) {
                 // retry
                 setTimeout(() => {
                     this.prepRecord(retry + 1);
@@ -189,6 +205,8 @@ class RecorderModel implements IRecorderModel {
                 // 録画準備失敗を通知
                 this.recordingEvent.emitPrepRecordingFailed(this.reserve);
             }
+        } finally {
+            this.abortController = null;
         }
     }
 
@@ -199,9 +217,6 @@ class RecorderModel implements IRecorderModel {
         this.isStopPrepRec = false;
         this.isPrepRecording = false;
         this.isRecording = false;
-
-        // 録画準備失敗を通知
-        this.recordingEvent.emitCancelPrepRecording(this.reserve);
 
         this.eventEmitter.emit(RecorderModel.CANCEL_EVENT);
     }
@@ -722,13 +737,8 @@ class RecorderModel implements IRecorderModel {
 
     /**
      * 予約のキャンセル
-     * @param isPlanToDelete: boolean ファイルが削除される予定か
      */
-    public async cancel(isPlanToDelete: boolean): Promise<void> {
-        this.log.system.info(
-            `recording cancel reserveId: ${this.reserve.id}, recordedId: ${this.recordedId}, isPlanToDelete: ${isPlanToDelete}`,
-        );
-
+    private async _cancel(): Promise<void> {
         if (this.isPrepRecording === false && this.isRecording === false) {
             // 録画処理が開始されていない
             if (this.timerId !== null) {
@@ -745,21 +755,41 @@ class RecorderModel implements IRecorderModel {
                 }, 60 * 1000);
 
                 // 録画準備中
+                this.isStopPrepRec = true;
+                if (this.abortController) this.abortController.abort();
                 this.eventEmitter.once(RecorderModel.CANCEL_EVENT, () => {
                     clearTimeout(timerId);
                     // prep rec キャンセル完了
                     resolve();
                 });
-                this.isStopPrepRec = true;
             });
         } else if (this.isRecording === true) {
-            this.isPlanToDelete = isPlanToDelete;
             this.log.system.info(`stop recording: ${this.reserve.id}`);
             // 録画中
             if (this.stream !== null) {
                 this.stream.destroy();
                 this.stream.push(null); // eof 通知
             }
+        }
+    }
+
+    /**
+     * 予約のキャンセル
+     * @param isPlanToDelete: boolean ファイルが削除される予定か
+     */
+    public async cancel(isPlanToDelete: boolean): Promise<void> {
+        this.log.system.info(
+            `recording cancel reserveId: ${this.reserve.id}, recordedId: ${this.recordedId}, isPlanToDelete: ${isPlanToDelete}`,
+        );
+
+        this.isPlanToDelete = isPlanToDelete;
+
+        await this._cancel();
+
+        if (this.isPrepRecording === true) {
+            // 録画準備失敗を通知
+            this.recordingEvent.emitCancelPrepRecording(this.reserve);
+        } else if (this.isRecording === true) {
             this.isNeedDeleteReservation = false;
         }
     }
@@ -820,15 +850,31 @@ class RecorderModel implements IRecorderModel {
                         }
                     }
                 } else if (this.reserve.startAt < newReserve.startAt) {
-                    // 開始時間が遅くなった
-                    this.log.system.info(
-                        `resetting recording timer reserveId: ${this.reserve.id}, recordedId: ${this.recordedId}`,
-                    );
-                    await this.cancel(false).catch(err => {
-                        this.log.system.error(`cancel recording error: ${newReserve.id}`);
-                        this.log.system.error(err);
-                    });
-                    this.setTimer(newReserve, isSuppressLog); // タイマー再セット
+                    // 開始時刻が遅くなった
+                    if (this.isRecording === false) {
+                        // まだ録画準備中なのでキャンセルしてタイマーを再セット
+                        this.log.system.info(
+                            `cancel prepare recording.`,
+                            `(reserveId: ${this.reserve.id}, programId: ${this.reserve.programId}, recordedId: ${this.recordedId})`,
+                        );
+                        await this._cancel().catch(err => {
+                            this.log.system.error(
+                                `cancel recording error: (reserveId: ${newReserve.id}, programId: ${this.reserve.programId})`,
+                            );
+                            this.log.system.error(err);
+                        });
+                        // NOTE: キャンセルエラーが発生したとしてもタイマーを再セット
+                        this.setTimer(newReserve, isSuppressLog);
+                    } else {
+                        // 録画中
+                        // NOTE:
+                        //  EPGstationがスケジュール変更を遅れて把握した可能性がある
+                        //  一度ストリームを開始した番組の開始時刻が変更されることはないのでここでは何もしない
+                        this.log.system.info(
+                            `Ignores schedule changes because this program is already recording.`,
+                            ` (reserveId: ${this.reserve.id}, programId: ${this.reserve.programId}, recordedId: ${this.recordedId})`,
+                        );
+                    }
                 }
             }
         }

--- a/src/model/operator/recording/RecorderModel.ts
+++ b/src/model/operator/recording/RecorderModel.ts
@@ -784,13 +784,16 @@ class RecorderModel implements IRecorderModel {
 
         this.isPlanToDelete = isPlanToDelete;
 
-        await this._cancel();
-
         if (this.isPrepRecording === true) {
+            await this._cancel();
             // 録画準備失敗を通知
             this.recordingEvent.emitCancelPrepRecording(this.reserve);
         } else if (this.isRecording === true) {
+            await this._cancel();
             this.isNeedDeleteReservation = false;
+        }
+        else {
+            await this._cancel();
         }
     }
 


### PR DESCRIPTION
## 概要(Summary)
番組の放送時刻変更および番組の組み替えに伴う番組削除への対応を強化

## 内容
### epgUpdater
- 番組編成変更に迅速に対応するため、epgUpdateIntervalTime間隔のキューのフラッシュに追加して、受信した番組がすでに開始している（※放送終了の変更）か開始時刻が5分以内の番組がキューにあれば迅速にdbへフラッシュする
- キューをフラッシュする必要がなかった場合は"updated"イベントを通知せず、スケジュールの無駄な更新を避ける
- 番組が削除された際の処理に問題があったため改善した。このことで、削除された番組が番組表に存在し続けて、正しい番組が裏に隠れて見えなくなる事象が解消する
### recording
- 録画中の場合、スケジュール更新によるキャンセルは行わない。これは、EPGstationの番組情報の更新が間に合わなかたことを示す事象であるから。録画を継続しても影響はない
- preprec（スタンバイ中）の番組の開始時刻変更を検知した場合はprecrecをキャンセルする。この際、10分ほどの通信タイムアウトを待たないでmirakurunとの通信を即座に閉じるためabortSignalを使用
- 録画対象の直前の番組が終了時刻延長になった場合、mirakurunから番組削除電文が届く場合がる。これにより録画が失敗しずらい様対処した（当該番組が存在しない状態でスケジュール更新すると警告は出力されるがレコードは削除されない様である。mirakurunから新しい当該番組情報が届けばスケジュールは正常に戻る）　※この事象をさらに改善するためにmirakurunへプルリクエストを行ったが取り込まれるかは現時点で不明