### PR TITLE
chore: Kodi 関連のタイプミス修正

### DIFF
--- a/doc/kodi.md
+++ b/doc/kodi.md
@@ -19,7 +19,7 @@ kodiHosts:
     - name: kodi1
       host: http://KodiHost:Port
       user: user
-      pass: password
+      password: password
 ```
 
 ## Kodi 本体から録画済み番組を再生する

--- a/src/model/api/ApiUtil.ts
+++ b/src/model/api/ApiUtil.ts
@@ -40,7 +40,7 @@ export default class ApiUtil implements IApiUtil {
     /**
      * kodi へビデオリンクを送信する
      * @param source: ビデオリンク
-     * @param hkodiInfo: KodiInfo
+     * @param kodiInfo: KodiInfo
      */
     public async sendToKodi(source: string, kodiInfo: KodiInfo): Promise<void> {
         const option: AxiosRequestConfig = {


### PR DESCRIPTION
## 概要(Summary)

* 関数の注釈の `hkodiInfo` を `kodiInfo`に修正しました。
* 以下の`sendToKodi()`では`password` を使用していますが、Kodi との連携文書 [doc/kodi.md](https://github.com/l3tnun/EPGStation/blob/master/doc/kodi.md) では `pass`と書かれていました。連携文書を修正し、実際の挙動とあわせました。

https://github.com/l3tnun/EPGStation/blob/v2/src/model/api/ApiUtil.ts#L63
```
        if (typeof kodiInfo.user !== 'undefined' && typeof kodiInfo.password !== 'undefined') {
            option.auth = {
                username: kodiInfo.user,
                password: kodiInfo.password,
            };
        }
```