### PR TITLE
subDirectory設定時にSuagger UIが正常表示されない問題を修正

### DIFF
--- a/src/model/service/ServiceServer.ts
+++ b/src/model/service/ServiceServer.ts
@@ -176,9 +176,9 @@ class ServiceServer implements IServiceServer {
         const indexContent = fs
             .readFileSync(path.join(pathToSwaggerUi, 'swagger-initializer.js'))
             .toString()
-            .replace('https://petstore.swagger.io/v2/swagger.json', '/api/docs');
+            .replace('https://petstore.swagger.io/v2/swagger.json', this.createUrl('/api/docs'));
 
-        this.app.get('/api-docs/swagger-initializer.js', (_req, res) => {
+        this.app.get(this.createUrl('/api-docs/swagger-initializer.js'), (_req, res) => {
             res.send(indexContent);
         });
 


### PR DESCRIPTION
## 概要(Summary)

subDirectory設定時にSuagger UIが正常表示されなかったので、決め打ちpathだった2か所を createUrl で置き換えるようにしました。
手元で軽く確認した限り、subDirectory設定有り/無しどちらも動きました。
ご確認よろしくお願いします。
