### PR TITLE
エンコード実行時エラーで終了しても元ファイルが削除されてしまう問題を修正

### DIFF
--- a/config/enc-enhance.js.template
+++ b/config/enc-enhance.js.template
@@ -163,6 +163,10 @@ Array.prototype.push.apply(args, [output]);
         throw new Error(err);
     });
 
+    child.on('close', (code) => {
+        process.exitCode = code;
+    });
+
     process.on('SIGINT', () => {
         child.kill('SIGINT');
     });

--- a/config/enc.js.template
+++ b/config/enc.js.template
@@ -66,6 +66,10 @@ child.on('error', (err) => {
     throw new Error(err);
 });
 
+child.on('close', (code) => {
+    process.exitCode = code;
+});
+
 process.on('SIGINT', () => {
     child.kill('SIGINT');
 });


### PR DESCRIPTION
## 概要(Summary)

エンコード完了時削除にチェックを入れた際正常に終了していなくてもファイルが削除されるケースが存在した
ffmpeg(childProcess)の終了コードを受け取り、親プロセスの終了コードに入れることでEPGStation側に失敗を通知できるようにした