### PR TITLE
FFmpeg 7.0でエンコードの進捗状況が表示されるよう修正

### DIFF
--- a/config/enc-enhance.js.template
+++ b/config/enc-enhance.js.template
@@ -77,10 +77,10 @@ Array.prototype.push.apply(args, [output]);
         for (let i = 0; i < strbyline.length; i++) {
             let str = strbyline[i];
             if (str.startsWith('frame')) {
-                // 想定log
-                // frame= 5159 fps= 11 q=29.0 size=  122624kB time=00:02:51.84 bitrate=5845.8kbits/s dup=19 drop=0 speed=0.372x
+                // 想定log ※ kBはffmpeg 7.0未満での表記
+                // frame= 5159 fps= 11 q=29.0 size=  122624(k|Ki)B time=00:02:51.84 bitrate=5845.8kbits/s dup=19 drop=0 speed=0.372x
                 const progress = {};
-                const ffmpeg_reg = /frame=\s*(?<frame>\d+)\sfps=\s*(?<fps>\d+(?:\.\d+)?)\sq=\s*(?<q>[+-]?\d+(?:\.\d+)?)\sL?size=\s*(?<size>\d+(?:\.\d+)?)kB\stime=\s*(?<time>\d+[:\.\d+]*)\sbitrate=\s*(?<bitrate>\d+(?:\.\d+)?)kbits\/s(?:\sdup=\s*(?<dup>\d+))?(?:\sdrop=\s*(?<drop>\d+))?\sspeed=\s*(?<speed>\d+(?:\.\d+)?)x/;
+                const ffmpeg_reg = /frame=\s*(?<frame>\d+)\sfps=\s*(?<fps>\d+(?:\.\d+)?)\sq=\s*(?<q>[+-]?\d+(?:\.\d+)?)\sL?size=\s*(?<size>\d+(?:\.\d+)?)(kB|KiB)\stime=\s*(?<time>\d+[:\.\d+]*)\sbitrate=\s*(?<bitrate>\d+(?:\.\d+)?)kbits\/s(?:\sdup=\s*(?<dup>\d+))?(?:\sdrop=\s*(?<drop>\d+))?\sspeed=\s*(?<speed>\d+(?:\.\d+)?)x/;
                 let ffmatch =str.match(ffmpeg_reg);
                 /**
                  * match結果


### PR DESCRIPTION
## 概要(Summary)

- Fixed #689 

## 動作確認環境

* Version of EPGStation: `2.10.0`
* Version of Mirakurun: `3.9.0-rc.4`
* Version of Node: `18.20.3`
* Version of NPM: `10.7.0`
* OS: node:18-bookworm-slim container on Ubuntu 20.04.6 LTS
* Architecture: x64

## その他

コメントは文字数の少なさ優先で `(k|Ki)B` 、コードは検索のしやすさ優先で `(kB|KiB)` としました。
(が、違和感ありましたらご指摘ください)