### PR TITLE
MySQL connection through UNIX socket

### DIFF
--- a/doc/conf-manual.md
+++ b/doc/conf-manual.md
@@ -160,14 +160,15 @@ dbType: mysql
 
 #### MySQL の接続設定（MySQL 使用時は必須）
 
-| 子プロパティ名 | 種類   | 必須 | 説明                         |
-| -------------- | ------ | ---- | ---------------------------- |
-| host           | string | yes  | MySQL が動作するホスト名     |
-| port           | number | no   | MySQL が待ち受けるポート番号 |
-| user           | string | yes  | DB 接続用のユーザー名        |
-| password       | string | yes  | DB 接続用のパスワード        |
-| database       | string | yes  | 使用するデータベース名       |
-| charset        | string | no   | 使用する文字コード           |
+| 子プロパティ名 | 種類   | 必須 | 説明                                 |
+| -------------- | ------ | ---- | ------------------------------------ |
+| host           | string | yes  | MySQL が動作するホスト名             |
+| port           | number | no   | MySQL が待ち受けるポート番号         |
+| socketPath     | string | no   | MySQL が待ち受けるソケットのフルパス |
+| user           | string | yes  | DB 接続用のユーザー名                |
+| password       | string | yes  | DB 接続用のパスワード                |
+| database       | string | yes  | 使用するデータベース名               |
+| charset        | string | no   | 使用する文字コード                   |
 
 ```yaml
 mysql:

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -35,6 +35,7 @@ switch (config.dbtype) {
             type: 'mysql',
             host: config.mysql.host,
             port: config.mysql.port,
+            socketPath: config.mysql.socketPath,
             username: config.mysql.user,
             password: config.mysql.password,
             database: config.mysql.database,

--- a/src/model/IConfigFile.ts
+++ b/src/model/IConfigFile.ts
@@ -64,6 +64,7 @@ export default interface IConfigFile {
         host: string;
         user: string;
         port: number;
+        socketPath: string;
         password: string;
         database: string;
         charset?: string;

--- a/src/model/db/DBOperator.ts
+++ b/src/model/db/DBOperator.ts
@@ -60,6 +60,7 @@ export default class DBOperator implements IDBOperator {
                 type: 'mysql',
                 host: this.config.mysql.host,
                 port: this.config.mysql.port,
+                socketPath: this.config.mysql.socketPath,
                 username: this.config.mysql.user,
                 password: this.config.mysql.password,
                 database: this.config.mysql.database,


### PR DESCRIPTION
## Why

現在 EPGStation では MySQL や MariaDB を使う場合に TCP による接続方法しか指定することができませんが、[docker-mirakurun-epgstation](https://github.com/l3tnun/docker-mirakurun-epgstation) がそうであるように、EPGStation と DB は同じマシン上で走らせることが多いように思われます。
その様なユースケース、データベースとアプリケーションを同一のマシン上でホストする場合、TCP による接続よりも UNIX ドメインソケットによる接続の方が高速であることが知られています。 https://www.percona.com/blog/need-to-connect-to-a-local-mysql-server-use-unix-domain-socket/

## 概要(Summary)

MySQL または MariaDB を EPGStation の DB として使う場合に、TCP 接続のアドレスとポートを指定する代わりにUNIXドメインソケットのパス `socketPath` を指定することもできるようにします。
実装としては、EPGStation で使われている mysql パッケージではコネクション時に `socketPath` を指定すれば UNIX ドメインソケットによって接続を行うため、コンフィグの値をそちらに引き回しています。https://www.npmjs.com/package/mysql#connection-options

## 動作確認

MariaDB 10.5.25 により行いました。