### PR TITLE
subDirectoryを設定時に外部アプリ視聴しようとすると404エラーになる問題を修正

### DIFF
--- a/client/src/model/state/onair/OnAirSelectStreamState.ts
+++ b/client/src/model/state/onair/OnAirSelectStreamState.ts
@@ -209,6 +209,6 @@ export default class OnAirSelectStreamState implements IOnAirSelectStreamState {
             return null;
         }
 
-        return `/api/streams/live/${channel.id.toString(10)}/m2ts/playlist?mode=${this.selectedStreamConfig}`;
+        return location.host + Util.getSubDirectory() + `/api/streams/live/${channel.id.toString(10)}/m2ts/playlist?mode=${this.selectedStreamConfig}`;
     }
 }


### PR DESCRIPTION
## 概要(Summary)

M2TSのダウンロードURIにサブディレクトリを含めるように変更

- Fixed #694
