### PR TITLE
Enable local cache for /api/thumbnails/{thumbnailId}

### DIFF
--- a/src/model/service/api/thumbnails/{thumbnailId}.ts
+++ b/src/model/service/api/thumbnails/{thumbnailId}.ts
@@ -15,6 +15,7 @@ export const get: Operation = async (req, res) => {
                 message: 'thumbnail is not Found',
             });
         } else {
+            res.header('Cache-Control', 'private, max-age=14400');
             api.responseFile(req, res, filePath, 'image/jpeg', false);
         }
     } catch (err: any) {


### PR DESCRIPTION
## Why

EPGStation v2.10.0 では、`/api/thumbnails/{thumbnailId}` のレスポンスには `Cache-Control` ヘッダが設定されておらず、番組のサムネイルが表示される度にサーバーへリクエストが飛ぶ状態にあります。

![GiZJpW3aYAAbzO0](https://github.com/user-attachments/assets/9f3e10b1-c5ba-4498-8e21-f408b3e18f35)

サムネイルとはいえ著作権保護されたコンテンツの一部なので共有キャッシュへ保存すべきでないのは分かるのですが、EPGStation をブラウザで開いているユーザーのローカルにはキャッシュしても良いのではないでしょうか？

## 概要(Summary)

`/api/thumbnails/{thumbnailId}` のレスポンスにおける `Cache-Control` ヘッダに `private, max-age=14400` を設定し、番組のサムネイルが4時間程度はローカルのキャッシュに保存されるようにします。

### 動作確認

アクセス制限を施した上で Cloudflare の CDN を通じて EPGStation v2.10.0 にアクセスする環境において、`Cache-Control` ヘッダに `private, max-age=14400` が設定されサムネイルがローカルにキャッシュされることと、Cloudflare の CDN にはキャッシュされていない事を確認しました。

<img width="1614" alt="スクリーンショット 2025-01-30 0 25 44" src="https://github.com/user-attachments/assets/6cb84055-b18f-41df-a7f2-6f13db2b921f" />

ここで、`Cf-Cache-Status` が `DYNAMIC` に設定されていますが、これは Cloudflare の CDN がキャッシュ対象と見做していない事を示しています。 cf. https://developers.cloudflare.com/cache/concepts/cache-responses/#dynamic