### PR TITLE
Remove unnecessary npm packages from Docker image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,7 +8,7 @@ RUN npm config set fetch-retries 10 \
 RUN npm install --no-save --loglevel=info
 COPY . /app/
 RUN npm run build --loglevel=info \
-    && npm prune --omit=dev
+    && rm -rf node_modules
 
 FROM node:18-alpine3.19 AS server-builder
 RUN apk add --no-cache g++ make pkgconf python3 py3-pip

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,7 +7,8 @@ RUN npm config set fetch-retries 10 \
     && npm config set fetch-retry-maxtimeout 600000
 RUN npm install --no-save --loglevel=info
 COPY . /app/
-RUN npm run build --loglevel=info
+RUN npm run build --loglevel=info \
+    && npm prune --omit=dev
 
 FROM node:18-alpine3.19 AS server-builder
 RUN apk add --no-cache g++ make pkgconf python3 py3-pip
@@ -23,7 +24,8 @@ RUN npm config set fetch-retries 10 \
 RUN npm install --no-save --loglevel=info
 COPY . .
 RUN rm -rf client
-RUN npm run build-server --loglevel=info
+RUN npm run build-server --loglevel=info \
+    && npm prune --omit=dev
 
 FROM node:18-alpine
 LABEL maintainer="l3tnun"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -10,7 +10,8 @@ RUN npm config set fetch-retries 10 \
 RUN npm install --no-save --loglevel=info
 # clientフォルダー外にビルドに必要なファイルが存在するため、全てコピーする。
 COPY . /app/
-RUN npm run build --loglevel=info
+RUN npm run build --loglevel=info \
+    && npm prune --omit=dev
 
 # サーバーはsqlite3のようなプラットフォーム依存のネイティブ・アドオンを含んでいる。そのため、各
 # TARGETPLATFORMごとにソースをビルドしなければならない。BUILDPLATFORM以外のTARGETPLATFORMでは、QEMU
@@ -36,7 +37,8 @@ RUN npm install --no-save --loglevel=info
 # をコピーする方法は，ファイルが追加された場合に変更する必要があるため採用しない。
 COPY . .
 RUN rm -rf client
-RUN npm run build-server --loglevel=info
+RUN npm run build-server --loglevel=info \
+    && npm prune --omit=dev
 
 FROM node:18-bookworm-slim
 LABEL maintainer="l3tnun"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -11,7 +11,7 @@ RUN npm install --no-save --loglevel=info
 # clientフォルダー外にビルドに必要なファイルが存在するため、全てコピーする。
 COPY . /app/
 RUN npm run build --loglevel=info \
-    && npm prune --omit=dev
+    && rm -rf node_modules
 
 # サーバーはsqlite3のようなプラットフォーム依存のネイティブ・アドオンを含んでいる。そのため、各
 # TARGETPLATFORMごとにソースをビルドしなければならない。BUILDPLATFORM以外のTARGETPLATFORMでは、QEMU


### PR DESCRIPTION
## Why

現在、l3tnun/epgstation で配布されている Docker イメージには ESLint 等のビルド時以外には不要な npm パッケージが含まれており、非圧縮状態で server と client 合わせて実に 410MB ほどイメージサイズを押し上げる結果となっています。
せっかく軽量なベースイメージを採用しているのに node_modules だけでイメージを重くしてしまうのは勿体無いので、配布イメージにはビルド時以外不要な npm パッケージを含まないようにしたいです。

## What

各 Dockerfile でサーバーをビルド後、最終イメージへそれをコピーする前に `npm prune --omit=dev` を行って devDependencies を削除します。
加えて、クライアント側については `vue-cli-service build` でバンドルが行われており node_modules 自体が不要なことから、最終イメージへコピーする前に削除を行います。
これにより、配布イメージにビルド時以外不要な npm パッケージを含まないようにできるかと思います。

### 動作確認

mirakc 2.4.9 と MySQL 互換 DB（TiDB Serverless）を使ってサーバー側の devDependencies とクライアント側の node_modules を削除した alpine ベースのコンテナでも x64 環境でストリーミング、録画、録画の視聴、番組表の閲覧、更新といった一通りの動作を行えることを確認しました。
とはいえ FFmpeg を自前で用意する都合上、完全に同一の Dockerfile で検証できた訳ではないです。