### PR TITLE
mysqlドライバをnode-mysql2に変更する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "mirakurun": "3.9.0-rc.4",
                 "mkdirp": "3.0.1",
                 "multer": "1.4.3",
-                "mysql": "2.18.1",
+                "mysql2": "3.14.1",
                 "openapi-types": "12.1.3",
                 "reflect-metadata": "0.2.2",
                 "socket.io": "4.7.5",
@@ -1389,6 +1389,15 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
+        "node_modules/aws-ssl-profiles": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+            "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/axios": {
             "version": "1.6.8",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
@@ -1453,14 +1462,6 @@
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
             "engines": {
                 "node": ">=0.6"
-            }
-        },
-        "node_modules/bignumber.js": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-            "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/bindings": {
@@ -2045,6 +2046,15 @@
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
             "optional": true
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
+            }
         },
         "node_modules/depd": {
             "version": "1.1.2",
@@ -2916,6 +2926,15 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
+        "node_modules/generate-function": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+            "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-property": "^1.0.2"
+            }
+        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3331,6 +3350,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+            "license": "MIT"
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3466,6 +3491,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3475,6 +3506,21 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/lru.min": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+            "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1.0.0",
+                "deno": ">=1.30.0",
+                "node": ">=8.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wellwelwel"
             }
         },
         "node_modules/make-error": {
@@ -4222,18 +4268,36 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
-        "node_modules/mysql": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-            "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+        "node_modules/mysql2": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.1.tgz",
+            "integrity": "sha512-7ytuPQJjQB8TNAYX/H2yhL+iQOnIBjAMam361R7UAL0lOVXWjtdrmoL9HYKqKoLp/8UUTRcvo1QPvK9KL7wA8w==",
+            "license": "MIT",
             "dependencies": {
-                "bignumber.js": "9.0.0",
-                "readable-stream": "2.3.7",
-                "safe-buffer": "5.1.2",
-                "sqlstring": "2.3.1"
+                "aws-ssl-profiles": "^1.1.1",
+                "denque": "^2.1.0",
+                "generate-function": "^2.3.1",
+                "iconv-lite": "^0.6.3",
+                "long": "^5.2.1",
+                "lru.min": "^1.0.0",
+                "named-placeholders": "^1.1.3",
+                "seq-queue": "^0.0.5",
+                "sqlstring": "^2.3.2"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 8.0"
+            }
+        },
+        "node_modules/mysql2/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/mz": {
@@ -4244,6 +4308,27 @@
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
                 "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/named-placeholders": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+            "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+            "license": "MIT",
+            "dependencies": {
+                "lru-cache": "^7.14.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/named-placeholders/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/nan": {
@@ -5225,6 +5310,11 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/seq-queue": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+            "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+        },
         "node_modules/serve-static": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -5507,9 +5597,10 @@
             }
         },
         "node_modules/sqlstring": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-            "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+            "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -7330,6 +7421,11 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
+        "aws-ssl-profiles": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+            "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="
+        },
         "axios": {
             "version": "1.6.8",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
@@ -7372,11 +7468,6 @@
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
-        },
-        "bignumber.js": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-            "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "bindings": {
             "version": "1.5.0",
@@ -7822,6 +7913,11 @@
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
             "optional": true
+        },
+        "denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
         },
         "depd": {
             "version": "1.1.2",
@@ -8480,6 +8576,14 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
+        "generate-function": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+            "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+            "requires": {
+                "is-property": "^1.0.2"
+            }
+        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -8784,6 +8888,11 @@
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true
         },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8896,6 +9005,11 @@
                 "streamroller": "^3.1.5"
             }
         },
+        "long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+        },
         "lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -8903,6 +9017,11 @@
             "requires": {
                 "yallist": "^4.0.0"
             }
+        },
+        "lru.min": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+            "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg=="
         },
         "make-error": {
             "version": "1.3.6",
@@ -9517,15 +9636,30 @@
                 }
             }
         },
-        "mysql": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-            "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+        "mysql2": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.1.tgz",
+            "integrity": "sha512-7ytuPQJjQB8TNAYX/H2yhL+iQOnIBjAMam361R7UAL0lOVXWjtdrmoL9HYKqKoLp/8UUTRcvo1QPvK9KL7wA8w==",
             "requires": {
-                "bignumber.js": "9.0.0",
-                "readable-stream": "2.3.7",
-                "safe-buffer": "5.1.2",
-                "sqlstring": "2.3.1"
+                "aws-ssl-profiles": "^1.1.1",
+                "denque": "^2.1.0",
+                "generate-function": "^2.3.1",
+                "iconv-lite": "^0.6.3",
+                "long": "^5.2.1",
+                "lru.min": "^1.0.0",
+                "named-placeholders": "^1.1.3",
+                "seq-queue": "^0.0.5",
+                "sqlstring": "^2.3.2"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                }
             }
         },
         "mz": {
@@ -9536,6 +9670,21 @@
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
                 "thenify-all": "^1.0.0"
+            }
+        },
+        "named-placeholders": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+            "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+            "requires": {
+                "lru-cache": "^7.14.1"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "7.18.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+                }
             }
         },
         "nan": {
@@ -10285,6 +10434,11 @@
                 }
             }
         },
+        "seq-queue": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+            "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+        },
         "serve-static": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -10477,9 +10631,9 @@
             }
         },
         "sqlstring": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-            "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+            "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
         },
         "ssri": {
             "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "mirakurun": "3.9.0-rc.4",
         "mkdirp": "3.0.1",
         "multer": "1.4.3",
-        "mysql": "2.18.1",
+        "mysql2": "3.14.1",
         "openapi-types": "12.1.3",
         "reflect-metadata": "0.2.2",
         "socket.io": "4.7.5",

--- a/src/model/db/DBOperator.ts
+++ b/src/model/db/DBOperator.ts
@@ -67,6 +67,7 @@ export default class DBOperator implements IDBOperator {
                 bigNumberStrings: false,
                 synchronize: false,
                 logging: false,
+                connectorPackage: 'mysql2',
                 entities: [entitie],
                 subscribers: [subscriber],
                 migrationsRun: true,


### PR DESCRIPTION
## 概要(Summary)

- typeormが呼び出すmysqlDriverをnode-mysql2に変更します。これにより以下のissueが解決します。
  - https://github.com/l3tnun/EPGStation/issues/714

### 動作確認環境
以下の環境で基本的な動作を確認しています。

- OS: Oracle Linux 9.5(kernel:  5.15.0-307.178.5.el9uek.x86_64)
- nodejs: 22.13.1
- mirakurun: 4.0.0-beta.16
- DB: mysql 9.3.0-u1-cloud(MySQL Enterprise - Cloud)

### 確認済みの事項

- [x] 認証プラグイン「caching_sha2_password」で作成されたユーザーでDBの初期化処理が実行されること
- [x] EPGStationが起動し、WebUIにアクセスできること
- [x] EPGがDBにストアされること
- [x] 予約ボタンを押し、時間になると録画が実行されること