### PR TITLE
config.yml で環境変数の interpolation に対応する

### DIFF
--- a/src/model/Configuration.ts
+++ b/src/model/Configuration.ts
@@ -8,6 +8,19 @@ import IConfiguration from './IConfiguration';
 import ILogger from './ILogger';
 import ILoggerModel from './ILoggerModel';
 
+const envType = new yaml.Type('!env', {
+    kind: 'scalar',
+    resolve: (data: string) => typeof data === 'string',
+    construct: (data: string) => {
+        const value = process.env[data];
+        if (typeof value === 'undefined') {
+            throw new Error(`environment variable ${data} is not defined`);
+        }
+        return value;
+    },
+});
+const ENV_SCHEMA = yaml.DEFAULT_SCHEMA.extend([envType]);
+
 /**
  * Configuration
  * コンフィグ設定取得
@@ -33,7 +46,7 @@ class Configuration implements IConfiguration {
         fs.watchFile(Configuration.CONFIG_FILE_PATH, async () => {
             this.log.system.info('updated config file');
             try {
-                const newConfig = <any>yaml.load(await fs.promises.readFile(Configuration.CONFIG_FILE_PATH, 'utf-8'));
+                const newConfig = <any>yaml.load(await fs.promises.readFile(Configuration.CONFIG_FILE_PATH, 'utf-8'), { schema: ENV_SCHEMA });
                 this.config = this.formatConfig(newConfig);
             } catch (err: any) {
                 this.log.system.error('read config error');
@@ -77,7 +90,7 @@ class Configuration implements IConfiguration {
         }
 
         // parse configFile
-        const newConfig: IConfigFile = <any>yaml.load(str);
+        const newConfig: IConfigFile = <any>yaml.load(str, { schema: ENV_SCHEMA });
 
         return this.formatConfig(newConfig);
     }


### PR DESCRIPTION
## Why

EPGStation の config.yml には DB の接続情報をはじめとする機微情報が一部含まれており平文で保存したくないのですが、一方でエンコード設定の様に公開しても問題なく、かつ頻繁に変更する可能性のある情報も含まれているため、config.yml 全文を暗号化すると運用上問題が出てしまいます。
従って両者を分離し、公開情報だけを含んだ config.yml に対して機微情報を補完するような機構が欲しいと思っています。

## What

js-yaml のカスタムタグ `!env` を用い、環境変数の interpolation を行える様にする機能を実装します。
これにより、例えば config.yaml を次の様に記述することで、MySQL に接続する際のユーザーは EPGStation から見える環境変数 `MYSQL_USER` の内容が、パスワードは環境変数 `MYSQL_PASSWORD` の内容が使われるようになり、機微情報を config.yml より分離できるようになるかと思います。

```yaml
dbtype: mysql
mysql:
    host: mysql
    port: 3306
    user: !env MYSQL_USER
    password: !env MYSQL_PASSWORD
    database: epgstation
```

### 動作確認

以下の環境で動作を確認しています。

- OS: Debian 13.5 (カーネルは 6.12.94+deb13-amd64)
- Node.js: v18.20.8
- mirakc: 3.4.76
- DB: TiDB v8.5.3 (TiDB Cloud で利用しており、DB への接続にあたっては https://github.com/fetburner/EPGStation/commit/fa87a52a5994eb3b8573dbfe997bed253ca8a655 の SSL サポート拡張を用いています)